### PR TITLE
feat: add basic turkish ui and card visuals

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="tr">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>UNO</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/public/cards/red_0.svg
+++ b/client/public/cards/red_0.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="120" viewBox="0 0 80 120">
+  <rect width="80" height="120" rx="10" ry="10" fill="#e74c3c"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60" fill="#fff">0</text>
+</svg>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -11,10 +11,14 @@
 }
 
 .card {
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  color: white;
+  width: 60px;
+  height: 90px;
+  border: none;
+  background-size: cover;
+  background-position: center;
+  border-radius: 8px;
   cursor: pointer;
+  transition: transform 0.3s ease;
 }
 
 .card.red { background: #e74c3c; }
@@ -22,3 +26,30 @@
 .card.green { background: #27ae60; }
 .card.blue { background: #3498db; }
 .card.wild { background: #7f8c8d; }
+
+.card.playing {
+  transform: translateY(-20px);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.players li.current {
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  .card {
+    width: 40px;
+    height: 60px;
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,41 @@ import './App.css';
 
 const socket = io(import.meta.env.VITE_SERVER_URL || 'http://localhost:3001');
 
+const translations = {
+  en: {
+    joinGame: 'Join Game',
+    name: 'Name',
+    room: 'Room',
+    addComputer: 'Add Computer',
+    join: 'Join',
+    roomHeading: 'Room',
+    start: 'Start',
+    topCard: 'Top Card',
+    yourHand: 'Your hand',
+    yourTurn: '(Your turn)',
+    draw: 'Draw',
+    players: 'Players',
+    turn: 'Turn',
+    cards: 'cards',
+  },
+  tr: {
+    joinGame: 'Oyuna Katıl',
+    name: 'İsim',
+    room: 'Oda',
+    addComputer: 'Bilgisayar Ekle',
+    join: 'Katıl',
+    roomHeading: 'Oda',
+    start: 'Başlat',
+    topCard: 'Üst Kart',
+    yourHand: 'Eliniz',
+    yourTurn: '(Sıra sizde)',
+    draw: 'Kart Çek',
+    players: 'Oyuncular',
+    turn: 'Sıra',
+    cards: 'kart',
+  },
+};
+
 function App() {
   const [id, setId] = useState('');
   const [name, setName] = useState('');
@@ -11,6 +46,10 @@ function App() {
   const [joined, setJoined] = useState(false);
   const [state, setState] = useState(null);
   const [ai, setAi] = useState(false);
+  const [lang, setLang] = useState('tr');
+  const [playingIndex, setPlayingIndex] = useState(null);
+
+  const t = (key) => translations[lang][key] || key;
 
   useEffect(() => {
     socket.on('connect', () => setId(socket.id));
@@ -31,8 +70,12 @@ function App() {
     socket.emit('start', { room, ai });
   };
 
-  const play = (card) => {
-    socket.emit('play', { room, card });
+  const play = (card, idx) => {
+    setPlayingIndex(idx);
+    setTimeout(() => {
+      socket.emit('play', { room, card });
+      setPlayingIndex(null);
+    }, 300);
   };
 
   const draw = () => {
@@ -42,14 +85,18 @@ function App() {
   if (!joined) {
     return (
       <div className="join">
-        <h2>Join Game</h2>
-        <input placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
-        <input placeholder="Room" value={room} onChange={e => setRoom(e.target.value)} />
+        <select className="lang-select" value={lang} onChange={e => setLang(e.target.value)}>
+          <option value="tr">Türkçe</option>
+          <option value="en">English</option>
+        </select>
+        <h2>{t('joinGame')}</h2>
+        <input placeholder={t('name')} value={name} onChange={e => setName(e.target.value)} />
+        <input placeholder={t('room')} value={room} onChange={e => setRoom(e.target.value)} />
         <label>
           <input type="checkbox" checked={ai} onChange={e => setAi(e.target.checked)} />
-          Add Computer
+          {t('addComputer')}
         </label>
-        <button onClick={join}>Join</button>
+        <button onClick={join}>{t('join')}</button>
       </div>
     );
   }
@@ -57,11 +104,11 @@ function App() {
   if (!state || !state.started) {
     return (
       <div className="lobby">
-        <h2>Room: {room}</h2>
+        <h2>{t('roomHeading')}: {room}</h2>
         <ul>
           {state?.players.map(p => <li key={p.id}>{p.name}</li>)}
         </ul>
-        <button onClick={start}>Start</button>
+        <button onClick={start}>{t('start')}</button>
       </div>
     );
   }
@@ -71,20 +118,28 @@ function App() {
 
   return (
     <div className="game">
-      <h2>Top Card: {state.top.color} {state.top.value}</h2>
-      <h3>Your hand {myTurn ? '(Your turn)' : ''}</h3>
+      <h2>{t('topCard')}: {state.top.color} {state.top.value}</h2>
+      <h3>{t('turn')}: {state.players.find(p => p.id === state.current)?.name}</h3>
+      <h3>{t('yourHand')} {myTurn ? t('yourTurn') : ''}</h3>
       <div className="hand">
         {me.hand.map((c, idx) => (
-          <button key={idx} className={`card ${c.color}`} onClick={() => play(c)}>
-            {c.color} {c.value}
+          <button
+            key={idx}
+            className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''}`}
+            onClick={() => play(c, idx)}
+            style={{ backgroundImage: `url(/cards/${c.color}_${c.value}.svg)` }}
+          >
+            <span className="sr-only">{c.color} {c.value}</span>
           </button>
         ))}
       </div>
-      <button onClick={draw}>Draw</button>
-      <h3>Players</h3>
-      <ul>
+      <button onClick={draw}>{t('draw')}</button>
+      <h3>{t('players')}</h3>
+      <ul className="players">
         {state.players.map(p => (
-          <li key={p.id}>{p.name}: {p.hand.length} cards</li>
+          <li key={p.id} className={state.current === p.id ? 'current' : ''}>
+            {p.name}: {p.hand.length} {t('cards')}
+          </li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- localize client UI with Turkish defaults and language switcher
- show player turn and render cards with images and simple play animation
- add sample UNO card asset and mobile-friendly styles

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a0d8d681708327bab7dfc79b9a12b2