### PR TITLE
Show card values on UNO cards

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -14,11 +14,15 @@
   width: 60px;
   height: 90px;
   border: none;
-  background-size: cover;
-  background-position: center;
   border-radius: 8px;
   cursor: pointer;
   transition: transform 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: bold;
+  color: #fff;
 }
 
 .card.red { background: #e74c3c; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -127,9 +127,9 @@ function App() {
             key={idx}
             className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''}`}
             onClick={() => play(c, idx)}
-            style={{ backgroundImage: `url(/cards/${c.color}_${c.value}.svg)` }}
+            aria-label={`${c.color} ${c.value}`}
           >
-            <span className="sr-only">{c.color} {c.value}</span>
+            {c.value}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show card values on card buttons for better clarity
- center text and adjust card styles to display values

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm run build` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a0dc4ee5008327a68fdc55ba688b09