### PR TITLE
Kartları büyüt ve Türkçe ikonlu sürükle-bırak desteği

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -16,8 +16,8 @@
 }
 
 .card {
-  width: 60px;
-  height: 90px;
+  width: 80px;
+  height: 120px;
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -26,7 +26,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: bold;
   color: #fff;
 }
@@ -81,7 +81,7 @@
 
 @media (max-width: 600px) {
   .card {
-    width: 40px;
-    height: 60px;
+    width: 50px;
+    height: 75px;
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,8 @@ const translations = {
     players: 'Players',
     turn: 'Turn',
     cards: 'cards',
+    colors: { red: 'Red', yellow: 'Yellow', green: 'Green', blue: 'Blue', wild: 'Wild' },
+    values: { skip: 'Skip', reverse: 'Reverse', draw2: 'Draw 2', wild: 'Wild', wild4: 'Wild +4' },
   },
   tr: {
     joinGame: 'Oyuna Katıl',
@@ -36,6 +38,8 @@ const translations = {
     players: 'Oyuncular',
     turn: 'Sıra',
     cards: 'kart',
+    colors: { red: 'Kırmızı', yellow: 'Sarı', green: 'Yeşil', blue: 'Mavi', wild: 'Özel' },
+    values: { skip: 'Atla', reverse: 'Yön Değiştir', draw2: 'Çek 2', wild: 'Joker', wild4: 'Çek 4 Joker' },
   },
 };
 
@@ -48,8 +52,20 @@ function App() {
   const [ai, setAi] = useState(false);
   const [lang, setLang] = useState('tr');
   const [playingIndex, setPlayingIndex] = useState(null);
+  const [hand, setHand] = useState([]);
+  const [dragIndex, setDragIndex] = useState(null);
 
   const t = (key) => translations[lang][key] || key;
+  const colorText = (color) => translations[lang].colors[color] || color;
+  const valueText = (value) => translations[lang].values[value] || value;
+  const cardIcons = {
+    skip: '🚫',
+    reverse: '🔁',
+    draw2: '+2',
+    wild: '🌈',
+    wild4: '🌈+4',
+  };
+  const displayValue = (val) => cardIcons[val] ? `${cardIcons[val]} ${valueText(val)}` : valueText(val);
 
   useEffect(() => {
     socket.on('connect', () => setId(socket.id));
@@ -59,6 +75,11 @@ function App() {
       socket.off('state');
     };
   }, []);
+
+  useEffect(() => {
+    const me = state?.players.find(p => p.id === id);
+    setHand(me ? [...me.hand] : []);
+  }, [state, id]);
 
   const join = () => {
     if (!name) return;
@@ -72,6 +93,11 @@ function App() {
 
   const play = (card, idx) => {
     setPlayingIndex(idx);
+    setHand(h => {
+      const newHand = [...h];
+      newHand.splice(idx, 1);
+      return newHand;
+    });
     setTimeout(() => {
       socket.emit('play', { room, card });
       setPlayingIndex(null);
@@ -82,12 +108,22 @@ function App() {
     socket.emit('draw', { room });
   };
 
+  const onDragStart = (index) => setDragIndex(index);
+  const onDrop = (index) => {
+    if (dragIndex === null) return;
+    const newHand = [...hand];
+    const [moved] = newHand.splice(dragIndex, 1);
+    newHand.splice(index, 0, moved);
+    setHand(newHand);
+    setDragIndex(null);
+  };
+
   if (!joined) {
     return (
       <div className="join">
         <select className="lang-select" value={lang} onChange={e => setLang(e.target.value)}>
           <option value="tr">Türkçe</option>
-          <option value="en">English</option>
+          <option value="en">İngilizce</option>
         </select>
         <h2>{t('joinGame')}</h2>
         <input placeholder={t('name')} value={name} onChange={e => setName(e.target.value)} />
@@ -113,23 +149,26 @@ function App() {
     );
   }
 
-  const me = state.players.find(p => p.id === id) || { hand: [] };
   const myTurn = state.current === id;
 
   return (
     <div className="game">
-      <h2>{t('topCard')}: {state.top.color} {state.top.value}</h2>
+      <h2>{t('topCard')}: {colorText(state.top.color)} {displayValue(state.top.value)}</h2>
       <h3>{t('turn')}: {state.players.find(p => p.id === state.current)?.name}</h3>
       <h3>{t('yourHand')} {myTurn ? t('yourTurn') : ''}</h3>
       <div className="hand">
-        {me.hand.map((c, idx) => (
+        {hand.map((c, idx) => (
           <button
             key={idx}
             className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''}`}
             onClick={() => play(c, idx)}
-            aria-label={`${c.color} ${c.value}`}
+            draggable
+            onDragStart={() => onDragStart(idx)}
+            onDragOver={e => e.preventDefault()}
+            onDrop={() => onDrop(idx)}
+            aria-label={`${colorText(c.color)} ${valueText(c.value)}`}
           >
-            {c.value}
+            {cardIcons[c.value] || c.value}
           </button>
         ))}
       </div>

--- a/server/uno.js
+++ b/server/uno.js
@@ -54,7 +54,7 @@ class Game {
       p.hand = this.deck.splice(0, 7);
     });
     if (ai) {
-      this.ai = { id: 'AI', name: 'Computer', hand: this.deck.splice(0, 7) };
+      this.ai = { id: 'AI', name: 'Bilgisayar', hand: this.deck.splice(0, 7) };
       this.players.push(this.ai);
     }
     this.discard = [this.deck.pop()];


### PR DESCRIPTION
## Summary
- Kart boyutlarını büyütüp mobilde güncelledim
- Özel kartlar için ikonlar ekleyip renk/değerleri Türkçeleştirdim
- Eldeki kartları sürükle-bırak ile yeniden sıralama desteği ekledim
- Bilgisayar oyuncusunun adını "Bilgisayar" yaptım

## Testing
- `npm test` (client)
- `npm test` (server)
- `npm run lint` (client)


------
https://chatgpt.com/codex/tasks/task_e_68a0e07c72348327b9bc082ffcc7e023