### PR TITLE
Configure server URL via env var and document Vercel setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ npm run dev
 ```
 İstemci varsayılan olarak `http://localhost:3001` adresine bağlanır.
 
-## Netlify'ya Deploy
-1. `client` klasörünü Netlify sitesine deploy edin.
+## Vercel'de Deploy
+1. `client` klasörünü Vercel üzerinde yayınlayın.
    - Build komutu: `npm run build`
    - Yayın klasörü: `dist`
-2. Netlify ortam değişkenlerine `VITE_SERVER_URL` olarak Socket.IO sunucunuzun URL'sini ekleyin.
+2. Vercel ortam değişkenlerine `VITE_SERVER_URL` olarak Socket.IO sunucunuzun URL'sini ekleyin (örneğin `https://uno-game-backend-bco7.onrender.com`).
 3. `server` klasörünü kalıcı bir Node.js barındırma servisine (Render, Heroku vb.) ayrı olarak deploy edin.
 
 Güle güle UNO oynayın!

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,7 +2,9 @@ import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
 import './App.css';
 
-const socket = io(import.meta.env.VITE_SERVER_URL || 'http://localhost:3001');
+// Use a configurable server URL to support both local and deployed environments
+const serverUrl = import.meta.env.VITE_SERVER_URL || 'http://localhost:3001';
+const socket = io(serverUrl);
 
 const translations = {
   en: {


### PR DESCRIPTION
## Summary
- Clarify client Socket.IO connection with configurable server URL
- Document how to set `VITE_SERVER_URL` when deploying on Vercel

## Testing
- `cd client && npm test`
- `npm run lint`
- `cd ../server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e3c45c908327a0c270eff4901075