### PR TITLE
Show card details on hover and enforce turn order

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -15,6 +15,7 @@
   justify-content: center;
 }
 
+
 .card {
   width: 80px;
   height: 120px;
@@ -29,6 +30,7 @@
   font-size: 2.5rem;
   font-weight: bold;
   color: #fff;
+  position: relative;
 }
 
 .card.red { background: #e74c3c; }
@@ -37,9 +39,35 @@
 .card.blue { background: #3498db; }
 .card.wild { background: #7f8c8d; }
 
-.card:hover {
+.card:hover:not(:disabled) {
   transform: translateY(-10px) scale(1.05) rotate(-3deg);
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.4);
+}
+
+.card:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.card .tooltip {
+  visibility: hidden;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  text-align: center;
+  padding: 4px 8px;
+  border-radius: 4px;
+  position: absolute;
+  bottom: -35px;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-size: 0.75rem;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.card:hover .tooltip {
+  visibility: visible;
 }
 
 @keyframes playCard {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -57,6 +57,8 @@ function App() {
   const [hand, setHand] = useState([]);
   const [dragIndex, setDragIndex] = useState(null);
 
+  const myTurn = state?.current === id;
+
   const t = (key) => translations[lang][key] || key;
   const colorText = (color) => translations[lang].colors[color] || color;
   const valueText = (value) => translations[lang].values[value] || value;
@@ -94,6 +96,7 @@ function App() {
   };
 
   const play = (card, idx) => {
+    if (!myTurn) return;
     setPlayingIndex(idx);
     setHand(h => {
       const newHand = [...h];
@@ -107,6 +110,7 @@ function App() {
   };
 
   const draw = () => {
+    if (!myTurn) return;
     socket.emit('draw', { room });
   };
 
@@ -150,9 +154,6 @@ function App() {
       </div>
     );
   }
-
-  const myTurn = state.current === id;
-
   return (
     <div className="game">
       <h2>{t('topCard')}: {colorText(state.top.color)} {displayValue(state.top.value)}</h2>
@@ -164,6 +165,7 @@ function App() {
             key={idx}
             className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''}`}
             onClick={() => play(c, idx)}
+            disabled={!myTurn}
             draggable
             onDragStart={() => onDragStart(idx)}
             onDragOver={e => e.preventDefault()}
@@ -171,10 +173,11 @@ function App() {
             aria-label={`${colorText(c.color)} ${valueText(c.value)}`}
           >
             {cardIcons[c.value] || c.value}
+            <span className="tooltip">{`${colorText(c.color)} ${displayValue(c.value)}`}</span>
           </button>
         ))}
       </div>
-      <button onClick={draw}>{t('draw')}</button>
+      <button onClick={draw} disabled={!myTurn}>{t('draw')}</button>
       <h3>{t('players')}</h3>
       <ul className="players">
         {state.players.map(p => (

--- a/server/index.js
+++ b/server/index.js
@@ -40,8 +40,7 @@ io.on('connection', socket => {
 
   socket.on('draw', ({ room }) => {
     const game = games[room];
-    if (game) {
-      game.draw(socket.id);
+    if (game && game.draw(socket.id)) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);
     }

--- a/server/uno.js
+++ b/server/uno.js
@@ -65,15 +65,8 @@ class Game {
     return this.players[this.turn];
   }
 
-  nextTurn(extra = 0) {
+  nextTurn() {
     this.turn = (this.turn + this.direction + this.players.length) % this.players.length;
-    if (extra > 0) {
-      for (let i = 0; i < extra; i++) {
-        const player = this.players[(this.turn + this.direction * i + this.players.length) % this.players.length];
-        player.hand.push(...this.deck.splice(0, 1));
-      }
-      this.turn = (this.turn + this.direction * extra + this.players.length) % this.players.length;
-    }
   }
 
   canPlay(card) {
@@ -98,28 +91,36 @@ class Game {
     switch (card.value) {
       case 'reverse':
         this.direction *= -1;
+        this.nextTurn();
         break;
       case 'skip':
         this.nextTurn();
+        this.nextTurn();
         break;
       case 'draw2':
-        this.nextTurn(2);
+        this.nextTurn();
+        this.currentPlayer().hand.push(...this.deck.splice(0, 2));
+        this.nextTurn();
         break;
       case 'wild4':
-        this.nextTurn(4);
+        this.nextTurn();
+        this.currentPlayer().hand.push(...this.deck.splice(0, 4));
+        this.nextTurn();
         break;
+      default:
+        this.nextTurn();
     }
 
-    this.nextTurn();
     return true;
   }
 
   draw(id) {
-    if (!this.started) return;
+    if (!this.started) return false;
     const player = this.currentPlayer();
-    if (player.id !== id) return;
+    if (player.id !== id) return false;
     player.hand.push(this.deck.pop());
     this.nextTurn();
+    return true;
   }
 
   checkAI(io, room) {
@@ -136,24 +137,32 @@ class Game {
           switch (card.value) {
             case 'reverse':
               this.direction *= -1;
+              this.nextTurn();
               break;
             case 'skip':
               this.nextTurn();
+              this.nextTurn();
               break;
             case 'draw2':
-              this.nextTurn(2);
+              this.nextTurn();
+              this.currentPlayer().hand.push(...this.deck.splice(0, 2));
+              this.nextTurn();
               break;
             case 'wild4':
-              this.nextTurn(4);
+              this.nextTurn();
+              this.currentPlayer().hand.push(...this.deck.splice(0, 4));
+              this.nextTurn();
               break;
+            default:
+              this.nextTurn();
           }
           break;
         }
       }
       if (!played) {
         player.hand.push(this.deck.pop());
+        this.nextTurn();
       }
-      this.nextTurn();
       io.to(room).emit('state', this.getState());
       this.checkAI(io, room);
     }


### PR DESCRIPTION
## Summary
- show translated card details when hovering over a card
- block play/draw actions when it's not the player's turn
- fix server turn rotation so a player can't play multiple times in a row

## Testing
- `npm test` (server)
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_68a0e763f3a88327898ee5aa6e9274e6