### PR TITLE
Add lobby listing and viewer mode with unique room names

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -56,6 +56,8 @@ function App() {
   const [playingIndex, setPlayingIndex] = useState(null);
   const [hand, setHand] = useState([]);
   const [dragIndex, setDragIndex] = useState(null);
+  const [lobbies, setLobbies] = useState([]);
+  const [error, setError] = useState('');
 
   const myTurn = state?.current === id;
 
@@ -74,9 +76,16 @@ function App() {
   useEffect(() => {
     socket.on('connect', () => setId(socket.id));
     socket.on('state', st => setState(st));
+    socket.on('lobbies', setLobbies);
+    socket.on('joinError', msg => {
+      setError(msg);
+      setJoined(false);
+    });
     return () => {
       socket.off('connect');
       socket.off('state');
+      socket.off('lobbies');
+      socket.off('joinError');
     };
   }, []);
 
@@ -85,9 +94,16 @@ function App() {
     setHand(me ? [...me.hand] : []);
   }, [state, id]);
 
-  const join = () => {
+  const joinLobby = (r) => {
     if (!name) return;
-    socket.emit('join', { room, name });
+    setRoom(r);
+    socket.emit('join', { room: r, name });
+    setJoined(true);
+  };
+
+  const createLobby = () => {
+    if (!name || !room) return;
+    socket.emit('join', { room, name, create: true });
     setJoined(true);
   };
 
@@ -132,13 +148,20 @@ function App() {
           <option value="en">İngilizce</option>
         </select>
         <h2>{t('joinGame')}</h2>
+        {error && <div className="error">{error}</div>}
         <input placeholder={t('name')} value={name} onChange={e => setName(e.target.value)} />
+        <h3>Aktif Lobbiler</h3>
+        <ul className="lobbies">
+          {lobbies.map(l => (
+            <li key={l.name}>
+              {l.name} {l.started ? '(başladı)' : ''}
+              <button onClick={() => joinLobby(l.name)}>{l.started ? 'İzle' : 'Katıl'}</button>
+            </li>
+          ))}
+        </ul>
+        <h3>Yeni Lobby</h3>
         <input placeholder={t('room')} value={room} onChange={e => setRoom(e.target.value)} />
-        <label>
-          <input type="checkbox" checked={ai} onChange={e => setAi(e.target.checked)} />
-          {t('addComputer')}
-        </label>
-        <button onClick={join}>{t('join')}</button>
+        <button onClick={createLobby}>Oluştur</button>
       </div>
     );
   }
@@ -150,6 +173,10 @@ function App() {
         <ul>
           {state?.players.map(p => <li key={p.id}>{p.name}</li>)}
         </ul>
+        <label>
+          <input type="checkbox" checked={ai} onChange={e => setAi(e.target.checked)} />
+          {t('addComputer')}
+        </label>
         <button onClick={start}>{t('start')}</button>
       </div>
     );

--- a/server/index.js
+++ b/server/index.js
@@ -11,21 +11,33 @@ const io = new Server(server, {
 
 const games = {};
 
+const getLobbies = () =>
+  Object.entries(games).map(([name, game]) => ({ name, started: game.started }));
+
 io.on('connection', socket => {
-  socket.on('join', ({ room, name }) => {
-    if (!games[room]) {
+  // send current lobbies on connect
+  socket.emit('lobbies', getLobbies());
+
+  socket.on('join', ({ room, name, create }) => {
+    if (create) {
+      if (games[room]) return socket.emit('joinError', 'exists');
       games[room] = new Game(room);
+    } else if (!games[room]) {
+      return socket.emit('joinError', 'notfound');
     }
-    games[room].addPlayer(socket.id, name);
+
+    const game = games[room];
+    game.addPlayer(socket.id, name);
     socket.join(room);
-    io.to(room).emit('state', games[room].getState());
+    io.to(room).emit('state', game.getState());
+    io.emit('lobbies', getLobbies());
   });
 
   socket.on('start', ({ room, ai }) => {
     const game = games[room];
-    if (game) {
-      game.start(ai);
+    if (game && game.start(ai)) {
       io.to(room).emit('state', game.getState());
+      io.emit('lobbies', getLobbies());
       game.checkAI(io, room);
     }
   });
@@ -56,6 +68,7 @@ io.on('connection', socket => {
         io.to(room).emit('state', game.getState());
       }
     });
+    io.emit('lobbies', getLobbies());
   });
 });
 

--- a/server/uno.js
+++ b/server/uno.js
@@ -36,8 +36,9 @@ class Game {
   }
 
   addPlayer(id, name) {
-    if (this.started) return;
+    if (this.started || this.players.find(p => p.id === id)) return false;
     this.players.push({ id, name, hand: [] });
+    return true;
   }
 
   removePlayer(id) {
@@ -49,6 +50,7 @@ class Game {
   }
 
   start(ai = false) {
+    if (this.players.length < 2 && !ai) return false;
     this.deck = createDeck();
     this.players.forEach(p => {
       p.hand = this.deck.splice(0, 7);
@@ -59,6 +61,7 @@ class Game {
     }
     this.discard = [this.deck.pop()];
     this.started = true;
+    return true;
   }
 
   currentPlayer() {


### PR DESCRIPTION
## Summary
- broadcast active lobbies and prevent duplicate room creation
- show lobby list and creation UI in client; allow viewers when game started
- block starting games with fewer than two players to keep turn order correct

## Testing
- `cd client && npm test`
- `cd server && npm test`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec628d988327982f9cfdaf66ebb7