### PR TITLE
feat: persist game sessions and AI takeover

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.0.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -29,7 +29,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2.5rem;
+  font-size: 2rem;
   font-weight: bold;
   color: #fff;
   position: relative;
@@ -115,8 +115,8 @@
 
 @media (max-width: 600px) {
   .join, .lobby, .game {
-    margin: 1rem;
-    padding: 1rem;
+    margin: 0.5rem;
+    padding: 0.5rem;
   }
   .hand {
     gap: 0.25rem;
@@ -124,6 +124,7 @@
   .card {
     width: 45px;
     height: 68px;
+    font-size: 1.2rem;
   }
 }
 
@@ -155,7 +156,7 @@
 }
 
 .app-title::after {
-  content: '0.2.2';
+  content: attr(data-version);
   position: absolute;
   top: 100%;
   left: 50%;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { io } from 'socket.io-client';
 import './App.css';
+import pkg from '../package.json';
 
 // Use a configurable server URL to support both local and deployed environments
 const serverUrl = import.meta.env.VITE_SERVER_URL || 'http://localhost:3001';
@@ -33,6 +34,7 @@ const translations = {
     values: { skip: 'Skip', reverse: 'Reverse', draw2: 'Draw 2', wild: 'Wild', wild4: 'Wild +4' },
     viewing: 'Viewing',
     follow: 'Follow turn',
+    leave: 'Leave Game',
   },
   tr: {
     joinGame: 'Oyuna Katıl',
@@ -60,6 +62,7 @@ const translations = {
     values: { skip: 'Atla', reverse: 'Yön Değiştir', draw2: 'Çek 2', wild: 'Joker', wild4: 'Çek 4 Joker' },
     viewing: 'İzlenen',
     follow: 'Sıradakini izle',
+    leave: 'Oyundan Ayrıl',
   },
 };
 
@@ -82,6 +85,7 @@ function App() {
   const [colorPicker, setColorPicker] = useState(null);
   const [watching, setWatching] = useState(null);
   const [follow, setFollow] = useState(true);
+  const [sorted, setSorted] = useState(false);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
@@ -130,21 +134,48 @@ function App() {
       if (follow) setWatching(state?.current || null);
     } else {
       const me = state?.players.find(p => p.id === id);
-      setHand(me ? [...me.hand] : []);
+      if (me) {
+        if (sorted) {
+          setHand(h => {
+            const serverHand = [...me.hand];
+            const existing = [...h];
+            const counts = serverHand.map(c => JSON.stringify(c));
+            const result = [];
+            existing.forEach(card => {
+              const key = JSON.stringify(card);
+              const idx = counts.indexOf(key);
+              if (idx !== -1) {
+                result.push(card);
+                counts[idx] = null;
+              }
+            });
+            counts.forEach((key, idx) => {
+              if (key !== null) result.push(serverHand[idx]);
+            });
+            return result;
+          });
+        } else {
+          setHand([...me.hand]);
+        }
+      }
     }
-  }, [state, id, spectator, follow]);
+  }, [state, id, spectator, follow, sorted]);
 
   const joinLobby = (r) => {
     if (!name) return;
     setRoom(r);
     socket.emit('join', { room: r, name });
+    localStorage.setItem('unoGame', JSON.stringify({ room: r, name }));
     setJoined(true);
+    setSorted(false);
   };
 
   const createLobby = () => {
     if (!name || !room) return;
     socket.emit('join', { room, name, create: true });
+    localStorage.setItem('unoGame', JSON.stringify({ room, name }));
     setJoined(true);
+    setSorted(false);
   };
 
   const start = () => {
@@ -193,6 +224,7 @@ function App() {
 
   const sortHand = () => {
     setHand(h => [...h].sort((a, b) => colorOrder.indexOf(a.color) - colorOrder.indexOf(b.color)));
+    setSorted(true);
   };
 
   const draw = () => {
@@ -214,6 +246,29 @@ function App() {
     setHand(newHand);
     setDragIndex(null);
   };
+
+  const leaveGame = () => {
+    socket.emit('leave', { room });
+    localStorage.removeItem('unoGame');
+    setJoined(false);
+    setState(null);
+    setSorted(false);
+  };
+
+  useEffect(() => {
+    const saved = localStorage.getItem('unoGame');
+    if (saved) {
+      try {
+        const { room: savedRoom, name: savedName } = JSON.parse(saved);
+        setName(savedName);
+        setRoom(savedRoom);
+        socket.emit('join', { room: savedRoom, name: savedName });
+        setJoined(true);
+      } catch {
+        // ignore parsing errors
+      }
+    }
+  }, []);
 
   const viewingPlayer = spectator
     ? state?.players.find(p => p.id === watching)
@@ -293,6 +348,7 @@ function App() {
           <>
             <button onClick={draw} disabled={!myTurn || actionPending}>{t('draw')}</button>
             <button onClick={sortHand}>{t('sort')}</button>
+            <button onClick={leaveGame}>{t('leave')}</button>
           </>
         )}
         <h3>{t('players')}</h3>
@@ -313,7 +369,7 @@ function App() {
   return (
     <>
       <header className="app-header">
-        <h1 className="app-title" title="0.2.2">{lang === 'tr' ? 'Uno Oyunu' : 'Uno Game'}</h1>
+        <h1 className="app-title" data-version={pkg.version} title={pkg.version}>{lang === 'tr' ? 'Uno Oyunu' : 'Uno Game'}</h1>
       </header>
       {content}
       {colorPicker && (

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
 const Game = require('./uno');
+const { version } = require('./package.json');
 
 const app = express();
 const server = http.createServer(app);
@@ -27,10 +28,13 @@ io.on('connection', socket => {
     }
 
     const game = games[room];
-    if (game.players.some(p => p.name.toLowerCase() === name.toLowerCase())) {
+    const existing = game.players.find(p => p.name.toLowerCase() === name.toLowerCase());
+    if (existing && existing.id) {
       return socket.emit('joinError', 'nameTaken');
     }
-    game.addPlayer(socket.id, name);
+    if (!game.addPlayer(socket.id, name)) {
+      return socket.emit('joinError', 'notfound');
+    }
     socket.join(room);
     io.to(room).emit('state', game.getState());
     io.emit('lobbies', getLobbies());
@@ -61,14 +65,25 @@ io.on('connection', socket => {
     }
   });
 
+  socket.on('leave', ({ room }) => {
+    const game = games[room];
+    if (game && game.replaceWithAI(socket.id)) {
+      socket.leave(room);
+      io.to(room).emit('state', game.getState());
+      game.checkAI(io, room);
+    }
+    io.emit('lobbies', getLobbies());
+  });
+
   socket.on('disconnect', () => {
     Object.keys(games).forEach(room => {
       const game = games[room];
-      game.removePlayer(socket.id);
+      game.disconnectPlayer(socket.id);
       if (game.isEmpty()) {
         delete games[room];
       } else {
         io.to(room).emit('state', game.getState());
+        game.checkAI(io, room);
       }
     });
     io.emit('lobbies', getLobbies());
@@ -76,4 +91,4 @@ io.on('connection', socket => {
 });
 
 const PORT = process.env.PORT || 3001;
-server.listen(PORT, () => console.log(`Server listening on ${PORT}`));
+server.listen(PORT, () => console.log(`Server v${version} listening on ${PORT}`));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "0.2.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server/uno.js
+++ b/server/uno.js
@@ -36,10 +36,22 @@ class Game {
   }
 
   addPlayer(id, name) {
+    const existing = this.players.find(p => p.name.toLowerCase() === name.toLowerCase());
+    if (existing) {
+      existing.id = id;
+      return true;
+    }
     if (this.started || this.players.find(p => p.id === id)) return false;
-    if (this.players.some(p => p.name.toLowerCase() === name.toLowerCase())) return false;
     this.players.push({ id, name, hand: [] });
     return true;
+  }
+
+  disconnectPlayer(id) {
+    const idx = this.players.findIndex(p => p.id === id);
+    if (idx !== -1) {
+      this.players[idx].id = null;
+      if (this.turn === idx) this.nextTurn();
+    }
   }
 
   removePlayer(id) {
@@ -47,7 +59,7 @@ class Game {
   }
 
   isEmpty() {
-    return this.players.length === 0;
+    return this.players.every(p => !p.id);
   }
 
   start(ai = false) {
@@ -57,8 +69,8 @@ class Game {
       p.hand = this.deck.splice(0, 7);
     });
     if (ai) {
-      this.ai = { id: 'AI', name: 'Bilgisayar', hand: this.deck.splice(0, 7) };
-      this.players.push(this.ai);
+      const aiPlayer = { id: `AI-${Date.now()}`, name: 'Bilgisayar', hand: this.deck.splice(0, 7), ai: true };
+      this.players.push(aiPlayer);
     }
     this.discard = [this.deck.pop()];
     this.started = true;
@@ -131,52 +143,62 @@ class Game {
     return true;
   }
 
+  replaceWithAI(id) {
+    const player = this.players.find(p => p.id === id);
+    if (!player) return false;
+    player.id = `AI-${id}`;
+    player.name = `${player.name} (pc)`;
+    player.ai = true;
+    return true;
+  }
+
   checkAI(io, room) {
-    if (!this.ai) return;
     const player = this.currentPlayer();
-    if (player.id === 'AI') {
-      // Simple AI: play first valid card else draw
-      let played = false;
-      for (let i = 0; i < player.hand.length; i++) {
-        if (this.canPlay(player.hand[i])) {
-          const card = player.hand.splice(i, 1)[0];
-          if (card.color === 'wild') {
-            card.color = COLORS[Math.floor(Math.random() * COLORS.length)];
-          }
-          this.discard.push(card);
-          played = true;
-          switch (card.value) {
-            case 'reverse':
-              this.direction *= -1;
-              this.nextTurn();
-              break;
-            case 'skip':
-              this.nextTurn();
-              this.nextTurn();
-              break;
-            case 'draw2':
-              this.nextTurn();
-              this.currentPlayer().hand.push(...this.deck.splice(0, 2));
-              this.nextTurn();
-              break;
-            case 'wild4':
-              this.nextTurn();
-              this.currentPlayer().hand.push(...this.deck.splice(0, 4));
-              this.nextTurn();
-              break;
-            default:
-              this.nextTurn();
-          }
+    if (!player || !player.ai) return;
+    const priority = { wild4: 5, draw2: 4, skip: 3, reverse: 2, wild: 1 };
+    const playable = player.hand.filter(c => this.canPlay(c));
+    if (playable.length) {
+      playable.sort((a, b) => (priority[b.value] || 0) - (priority[a.value] || 0));
+      const card = playable[0];
+      const idx = player.hand.findIndex(c => c === card);
+      player.hand.splice(idx, 1);
+      if (card.color === 'wild') {
+        const colorCounts = COLORS.map(color => ({
+          color,
+          count: player.hand.filter(c => c.color === color).length,
+        })).sort((a, b) => b.count - a.count);
+        this.discard.push({ color: colorCounts[0].color, value: card.value });
+      } else {
+        this.discard.push(card);
+      }
+      switch (card.value) {
+        case 'reverse':
+          this.direction *= -1;
+          this.nextTurn();
           break;
-        }
+        case 'skip':
+          this.nextTurn();
+          this.nextTurn();
+          break;
+        case 'draw2':
+          this.nextTurn();
+          this.currentPlayer().hand.push(...this.deck.splice(0, 2));
+          this.nextTurn();
+          break;
+        case 'wild4':
+          this.nextTurn();
+          this.currentPlayer().hand.push(...this.deck.splice(0, 4));
+          this.nextTurn();
+          break;
+        default:
+          this.nextTurn();
       }
-      if (!played) {
-        player.hand.push(this.deck.pop());
-        this.nextTurn();
-      }
-      io.to(room).emit('state', this.getState());
-      this.checkAI(io, room);
+    } else {
+      player.hand.push(this.deck.pop());
+      this.nextTurn();
     }
+    io.to(room).emit('state', this.getState());
+    this.checkAI(io, room);
   }
 
   getState() {


### PR DESCRIPTION
## Summary
- align client and server versions to 0.2.3 and log it on server start
- preserve player sessions via local storage and allow AI takeover on leave
- refine card styling and mobile layout while keeping sorted hands ordered

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a0fdaf70a08327ba9f3a5ff9863851