### PR TITLE
End game on empty hand and add English translations

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,6 +35,15 @@ const translations = {
     viewing: 'Viewing',
     follow: 'Follow turn',
     leave: 'Leave Game',
+    started: 'started',
+    watch: 'Watch',
+    newLobby: 'New Lobby',
+    create: 'Create',
+    developedBy: 'Developed by Mustafa Evleksiz',
+    english: 'English',
+    turkish: 'Turkish',
+    winner: 'Winner',
+    activeLobbies: 'Active Lobbies',
   },
   tr: {
     joinGame: 'Oyuna Katıl',
@@ -63,6 +72,15 @@ const translations = {
     viewing: 'İzlenen',
     follow: 'Sıradakini izle',
     leave: 'Oyundan Ayrıl',
+    started: 'başladı',
+    watch: 'İzle',
+    newLobby: 'Yeni Lobby',
+    create: 'Oluştur',
+    developedBy: 'Mustafa Evleksiz tarafından geliştirilmiştir',
+    english: 'İngilizce',
+    turkish: 'Türkçe',
+    winner: 'Kazanan',
+    activeLobbies: 'Aktif Lobbiler',
   },
 };
 
@@ -280,29 +298,30 @@ function App() {
     content = (
       <div className="join">
         <select className="lang-select" value={lang} onChange={e => setLang(e.target.value)}>
-          <option value="tr">Türkçe</option>
-          <option value="en">İngilizce</option>
+          <option value="tr">{t('turkish')}</option>
+          <option value="en">{t('english')}</option>
         </select>
         <h2>{t('joinGame')}</h2>
         <input placeholder={t('name')} value={name} onChange={e => setName(e.target.value)} />
-        <h3>Aktif Lobbiler</h3>
+        <h3>{t('activeLobbies')}</h3>
         <ul className="lobbies">
           {lobbies.map(l => (
             <li key={l.name}>
-              {l.name} {l.started ? '(başladı)' : ''}
-              <button onClick={() => joinLobby(l.name)}>{l.started ? 'İzle' : 'Katıl'}</button>
+              {l.name} {l.started ? `(${t('started')})` : ''}
+              <button onClick={() => joinLobby(l.name)}>{l.started ? t('watch') : t('join')}</button>
             </li>
           ))}
         </ul>
-        <h3>Yeni Lobby</h3>
+        <h3>{t('newLobby')}</h3>
         <input placeholder={t('room')} value={room} onChange={e => setRoom(e.target.value)} />
-        <button onClick={createLobby}>Oluştur</button>
+        <button onClick={createLobby}>{t('create')}</button>
       </div>
     );
   } else if (!state || !state.started) {
     content = (
       <div className="lobby">
         <h2>{t('roomHeading')}: {room}</h2>
+        {state?.winner && <h3>{t('winner')}: {state.players.find(p => p.id === state.winner)?.name}</h3>}
         <ul>
           {state?.players.map(p => <li key={p.id}>{p.name}</li>)}
         </ul>
@@ -385,7 +404,7 @@ function App() {
         </div>
       )}
       {toast && <div className="toast">{toast}</div>}
-      <footer className="app-footer">Mustafa Evleksiz tarafından geliştirilmiştir</footer>
+      <footer className="app-footer">{t('developedBy')}</footer>
     </>
   );
 }

--- a/server/index.js
+++ b/server/index.js
@@ -54,6 +54,7 @@ io.on('connection', socket => {
     if (game && game.play(socket.id, card)) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);
+      if (!game.started) io.emit('lobbies', getLobbies());
     }
   });
 
@@ -62,6 +63,7 @@ io.on('connection', socket => {
     if (game && game.draw(socket.id)) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);
+      if (!game.started) io.emit('lobbies', getLobbies());
     }
   });
 

--- a/server/uno.js
+++ b/server/uno.js
@@ -33,6 +33,7 @@ class Game {
     this.discard = [];
     this.deck = [];
     this.ai = null;
+    this.winner = null;
   }
 
   addPlayer(id, name) {
@@ -74,6 +75,7 @@ class Game {
     }
     this.discard = [this.deck.pop()];
     this.started = true;
+    this.winner = null;
     return true;
   }
 
@@ -106,6 +108,12 @@ class Game {
       this.discard.push({ color: card.chosenColor, value: card.value });
     } else {
       this.discard.push(card);
+    }
+
+    if (player.hand.length === 0) {
+      this.started = false;
+      this.winner = player.id;
+      return true;
     }
 
     switch (card.value) {
@@ -171,34 +179,39 @@ class Game {
       } else {
         this.discard.push(card);
       }
-      switch (card.value) {
-        case 'reverse':
-          this.direction *= -1;
-          this.nextTurn();
-          break;
-        case 'skip':
-          this.nextTurn();
-          this.nextTurn();
-          break;
-        case 'draw2':
-          this.nextTurn();
-          this.currentPlayer().hand.push(...this.deck.splice(0, 2));
-          this.nextTurn();
-          break;
-        case 'wild4':
-          this.nextTurn();
-          this.currentPlayer().hand.push(...this.deck.splice(0, 4));
-          this.nextTurn();
-          break;
-        default:
-          this.nextTurn();
+      if (player.hand.length === 0) {
+        this.started = false;
+        this.winner = player.id;
+      } else {
+        switch (card.value) {
+          case 'reverse':
+            this.direction *= -1;
+            this.nextTurn();
+            break;
+          case 'skip':
+            this.nextTurn();
+            this.nextTurn();
+            break;
+          case 'draw2':
+            this.nextTurn();
+            this.currentPlayer().hand.push(...this.deck.splice(0, 2));
+            this.nextTurn();
+            break;
+          case 'wild4':
+            this.nextTurn();
+            this.currentPlayer().hand.push(...this.deck.splice(0, 4));
+            this.nextTurn();
+            break;
+          default:
+            this.nextTurn();
+        }
       }
     } else {
       player.hand.push(this.deck.pop());
       this.nextTurn();
     }
     io.to(room).emit('state', this.getState());
-    this.checkAI(io, room);
+    if (this.started) this.checkAI(io, room);
   }
 
   getState() {
@@ -206,7 +219,8 @@ class Game {
       started: this.started,
       players: this.players.map(p => ({ id: p.id, name: p.name, hand: p.hand })),
       current: this.currentPlayer() ? this.currentPlayer().id : null,
-      top: this.discard[this.discard.length - 1]
+      top: this.discard[this.discard.length - 1],
+      winner: this.winner
     };
   }
 }


### PR DESCRIPTION
## Summary
- Add missing English translations for lobby, controls and footer and display winner when a game ends
- Bump client version to 0.2.4
- Detect when a player runs out of cards and end the game, updating lobby state

## Testing
- `npm test` (server)
- `npm start` (server)
- `npm test` (client)
- `npm run lint` (client)


------
https://chatgpt.com/codex/tasks/task_e_68a1012f64a48327a2575d5f24331b69