### PR TITLE
Add swap hands card and improve UI

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -41,6 +41,25 @@
 .card.blue { background: #3498db; }
 .card.wild { background: #7f8c8d; }
 
+.card.small {
+  width: 40px;
+  height: 60px;
+  font-size: 1.2rem;
+  cursor: default;
+}
+
+.top-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.top-label {
+  font-size: 0.9rem;
+}
+
 .card:hover:not(:disabled) {
   transform: translateY(-10px) scale(1.05) rotate(-3deg);
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.4);
@@ -218,3 +237,36 @@
 .color-picker .yellow { background: #f1c40f; color: #000; }
 .color-picker .green { background: #27ae60; }
 .color-picker .blue { background: #3498db; }
+
+.player-picker .player-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.player-picker button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.winner-banner {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 2rem 3rem;
+  border-radius: 12px;
+  font-size: 2rem;
+  animation: winnerPop 1s ease forwards;
+  z-index: 1000;
+}
+
+@keyframes winnerPop {
+  0% { transform: translate(-50%, -50%) scale(0.5); opacity: 0; }
+  60% { transform: translate(-50%, -50%) scale(1.1); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(1); }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -31,7 +31,7 @@ const translations = {
     chooseColor: 'Choose a color',
     sort: 'Sort Cards',
     colors: { red: 'Red', yellow: 'Yellow', green: 'Green', blue: 'Blue', wild: 'Wild' },
-    values: { skip: 'Skip', reverse: 'Reverse', draw2: 'Draw 2', wild: 'Wild', wild4: 'Wild +4' },
+    values: { skip: 'Skip', reverse: 'Reverse', draw2: 'Draw 2', wild: 'Wild', wild4: 'Wild +4', swap: 'Swap Hands' },
     viewing: 'Viewing',
     follow: 'Follow turn',
     leave: 'Leave Game',
@@ -43,6 +43,8 @@ const translations = {
     english: 'English',
     turkish: 'Turkish',
     winner: 'Winner',
+    wins: 'wins!',
+    choosePlayer: 'Choose a player',
     activeLobbies: 'Active Lobbies',
   },
   tr: {
@@ -68,7 +70,7 @@ const translations = {
     chooseColor: 'Renk seçin',
     sort: 'Kartları sırala',
     colors: { red: 'Kırmızı', yellow: 'Sarı', green: 'Yeşil', blue: 'Mavi', wild: 'Özel' },
-    values: { skip: 'Atla', reverse: 'Yön Değiştir', draw2: 'Çek 2', wild: 'Joker', wild4: 'Çek 4 Joker' },
+    values: { skip: 'Atla', reverse: 'Yön Değiştir', draw2: 'Çek 2', wild: 'Joker', wild4: 'Çek 4 Joker', swap: 'El Değiştir' },
     viewing: 'İzlenen',
     follow: 'Sıradakini izle',
     leave: 'Oyundan Ayrıl',
@@ -80,6 +82,8 @@ const translations = {
     english: 'İngilizce',
     turkish: 'Türkçe',
     winner: 'Kazanan',
+    wins: 'kazandı!',
+    choosePlayer: 'Bir oyuncu seçin',
     activeLobbies: 'Aktif Lobbiler',
   },
 };
@@ -101,6 +105,7 @@ function App() {
   const colorOrder = ['red', 'yellow', 'green', 'blue', 'wild'];
   const COLORS = ['red', 'yellow', 'green', 'blue'];
   const [colorPicker, setColorPicker] = useState(null);
+  const [swapPicker, setSwapPicker] = useState(null);
   const [watching, setWatching] = useState(null);
   const [follow, setFollow] = useState(true);
   const [sorted, setSorted] = useState(false);
@@ -117,6 +122,7 @@ function App() {
     draw2: '+2',
     wild: '🌈',
     wild4: '🌈+4',
+    swap: '🔄',
   };
   const displayValue = (val) => cardIcons[val] ? `${cardIcons[val]} ${valueText(val)}` : valueText(val);
 
@@ -200,7 +206,7 @@ function App() {
     socket.emit('start', { room, ai });
   };
 
-  const performPlay = (card, idx) => {
+  const performPlay = (card, idx, target) => {
     setActionPending(true);
     setPlayingIndex(idx);
     setHand(h => {
@@ -209,7 +215,7 @@ function App() {
       return newHand;
     });
     setTimeout(() => {
-      socket.emit('play', { room, card });
+      socket.emit('play', { room, card, target });
       setPlayingIndex(null);
     }, 400);
   };
@@ -237,7 +243,18 @@ function App() {
     if (!colorPicker) return;
     const { card, idx } = colorPicker;
     setColorPicker(null);
-    performPlay({ ...card, chosenColor: color }, idx);
+    if (card.value === 'swap') {
+      setSwapPicker({ card: { ...card, chosenColor: color }, idx });
+    } else {
+      performPlay({ ...card, chosenColor: color }, idx);
+    }
+  };
+
+  const chooseSwapTarget = (targetId) => {
+    if (!swapPicker) return;
+    const { card, idx } = swapPicker;
+    setSwapPicker(null);
+    performPlay(card, idx, targetId);
   };
 
   const sortHand = () => {
@@ -335,7 +352,16 @@ function App() {
   } else {
     content = (
       <div className="game">
-        <h2>{t('topCard')}: {colorText(state.top.color)} {displayValue(state.top.value)}</h2>
+        <div className="top-area">
+          <h2>{t('topCard')}</h2>
+          <div
+            className={`card ${state.top.color} small`}
+            aria-label={`${colorText(state.top.color)} ${valueText(state.top.value)}`}
+          >
+            {cardIcons[state.top.value] || state.top.value}
+          </div>
+          <span className="top-label">{colorText(state.top.color)} {displayValue(state.top.value)}</span>
+        </div>
         <h3>{t('turn')}: {state.players.find(p => p.id === state.current)?.name}</h3>
         {spectator ? (
           <>
@@ -401,6 +427,21 @@ function App() {
               </button>
             ))}
           </div>
+        </div>
+      )}
+      {swapPicker && (
+        <div className="color-picker player-picker">
+          <p>{t('choosePlayer')}</p>
+          <div className="player-options">
+            {state.players.filter(p => p.id !== id).map(p => (
+              <button key={p.id} onClick={() => chooseSwapTarget(p.id)}>{p.name}</button>
+            ))}
+          </div>
+        </div>
+      )}
+      {state?.winner && (
+        <div className="winner-banner">
+          {state.players.find(p => p.id === state.winner)?.name} {t('wins')}
         </div>
       )}
       {toast && <div className="toast">{toast}</div>}

--- a/server/index.js
+++ b/server/index.js
@@ -49,9 +49,9 @@ io.on('connection', socket => {
     }
   });
 
-  socket.on('play', ({ room, card }) => {
+  socket.on('play', ({ room, card, target }) => {
     const game = games[room];
-    if (game && game.play(socket.id, card)) {
+    if (game && game.play(socket.id, card, target)) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);
       if (!game.started) io.emit('lobbies', getLobbies());

--- a/server/uno.js
+++ b/server/uno.js
@@ -9,7 +9,7 @@ function createDeck() {
     SPECIALS.forEach(type => deck.push({ color, value: type }));
   });
   // Add wild cards
-  ['wild', 'wild4'].forEach(type => {
+  ['wild', 'wild4', 'swap'].forEach(type => {
     for (let i = 0; i < 4; i++) deck.push({ color: 'wild', value: type });
   });
   return shuffle(deck);
@@ -73,7 +73,12 @@ class Game {
       const aiPlayer = { id: `AI-${Date.now()}`, name: 'Bilgisayar', hand: this.deck.splice(0, 7), ai: true };
       this.players.push(aiPlayer);
     }
-    this.discard = [this.deck.pop()];
+    let first = this.drawCard();
+    while (first.color === 'wild' || typeof first.value !== 'number') {
+      this.deck.unshift(first);
+      first = this.drawCard();
+    }
+    this.discard = [first];
     this.started = true;
     this.winner = null;
     return true;
@@ -88,6 +93,7 @@ class Game {
   }
 
   canPlay(card) {
+    if (!card) return false;
     const top = this.discard[this.discard.length - 1];
     return (
       card.color === 'wild' ||
@@ -96,7 +102,16 @@ class Game {
     );
   }
 
-  play(id, card) {
+  drawCard() {
+    if (this.deck.length === 0) {
+      const top = this.discard.pop();
+      this.deck = shuffle(this.discard);
+      this.discard = [top];
+    }
+    return this.deck.pop();
+  }
+
+  play(id, card, target) {
     if (!this.started) return false;
     const player = this.currentPlayer();
     if (player.id !== id) return false;
@@ -127,12 +142,19 @@ class Game {
         break;
       case 'draw2':
         this.nextTurn();
-        this.currentPlayer().hand.push(...this.deck.splice(0, 2));
+        this.currentPlayer().hand.push(this.drawCard(), this.drawCard());
         this.nextTurn();
         break;
       case 'wild4':
         this.nextTurn();
-        this.currentPlayer().hand.push(...this.deck.splice(0, 4));
+        this.currentPlayer().hand.push(this.drawCard(), this.drawCard(), this.drawCard(), this.drawCard());
+        this.nextTurn();
+        break;
+      case 'swap':
+        if (target) {
+          const other = this.players.find(p => p.id === target);
+          if (other) [player.hand, other.hand] = [other.hand, player.hand];
+        }
         this.nextTurn();
         break;
       default:
@@ -146,7 +168,7 @@ class Game {
     if (!this.started) return false;
     const player = this.currentPlayer();
     if (player.id !== id) return false;
-    player.hand.push(this.deck.pop());
+    player.hand.push(this.drawCard());
     this.nextTurn();
     return true;
   }
@@ -163,8 +185,8 @@ class Game {
   checkAI(io, room) {
     const player = this.currentPlayer();
     if (!player || !player.ai) return;
-    const priority = { wild4: 5, draw2: 4, skip: 3, reverse: 2, wild: 1 };
-    const playable = player.hand.filter(c => this.canPlay(c));
+    const priority = { wild4: 5, draw2: 4, skip: 3, reverse: 2, swap: 2, wild: 1 };
+    const playable = player.hand.filter(c => c && this.canPlay(c));
     if (playable.length) {
       playable.sort((a, b) => (priority[b.value] || 0) - (priority[a.value] || 0));
       const card = playable[0];
@@ -194,12 +216,17 @@ class Game {
             break;
           case 'draw2':
             this.nextTurn();
-            this.currentPlayer().hand.push(...this.deck.splice(0, 2));
+            this.currentPlayer().hand.push(this.drawCard(), this.drawCard());
             this.nextTurn();
             break;
           case 'wild4':
             this.nextTurn();
-            this.currentPlayer().hand.push(...this.deck.splice(0, 4));
+            this.currentPlayer().hand.push(this.drawCard(), this.drawCard(), this.drawCard(), this.drawCard());
+            this.nextTurn();
+            break;
+          case 'swap':
+            const target = this.players.filter(p => p.id !== player.id).sort((a, b) => b.hand.length - a.hand.length)[0];
+            if (target) [player.hand, target.hand] = [target.hand, player.hand];
             this.nextTurn();
             break;
           default:
@@ -207,7 +234,7 @@ class Game {
         }
       }
     } else {
-      player.hand.push(this.deck.pop());
+      player.hand.push(this.drawCard());
       this.nextTurn();
     }
     io.to(room).emit('state', this.getState());


### PR DESCRIPTION
## Summary
- Fix server crash when checking playability without a card and replenish deck when empty
- Add Wild Swap Hands card with hand-swapping logic and target selection
- Improve visuals: top card preview, winner banner and assorted UI polish

## Testing
- `cd server && npm test`
- `cd client && npm test`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a167d51f788327a2d934fd9aa1aba6