### PR TITLE
Improve UI and special card handling

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
     <title>UNO</title>
   </head>
   <body>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -145,18 +145,36 @@
     height: 68px;
     font-size: 1.2rem;
   }
+  .app-header {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+  .app-title {
+    font-size: 2rem;
+  }
 }
 
 .toast {
   position: fixed;
   top: 1rem;
   right: 1rem;
-  background: rgba(0, 0, 0, 0.85);
+  background: rgba(0, 0, 0, 0.9);
   color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  animation: fadeIn 0.3s ease;
+  padding: 0.75rem 1.25rem;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border-left: 4px solid #ffcc00;
+  animation: slideIn 0.3s ease, fadeOut 0.5s ease 2.5s forwards;
   z-index: 1000;
+}
+
+@keyframes slideIn {
+  from { transform: translateX(100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; }
 }
 
 .app-header, .app-footer {
@@ -192,6 +210,49 @@
   margin-top: 4px;
 }
 
+.game-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.game-actions button {
+  border: none;
+  color: #fff;
+}
+
+.game-actions button:hover {
+  opacity: 0.9;
+}
+
+.draw-btn {
+  background: linear-gradient(145deg, #27ae60, #219150);
+}
+
+.sort-btn {
+  background: linear-gradient(145deg, #3498db, #2c7ac7);
+}
+
+.leave-btn {
+  background: linear-gradient(145deg, #e74c3c, #c0392b);
+}
+
+.players {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.players li {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+}
+
 .app-title:hover::after {
   opacity: 1;
 }
@@ -206,27 +267,33 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.85);
-  padding: 1rem;
-  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.9);
+  padding: 1.5rem 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
   z-index: 1000;
 }
 
 .color-picker .color-btn {
-  width: 50px;
-  height: 50px;
-  border: none;
-  border-radius: 4px;
+  width: 60px;
+  height: 60px;
+  border: 2px solid #fff;
+  border-radius: 50%;
   cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.color-picker .color-btn:hover {
+  transform: scale(1.1);
 }
 
 .color-picker .color-options {
   display: flex;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
 .color-picker p {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -30,6 +30,7 @@ const translations = {
     nameTaken: 'Name already used',
     chooseColor: 'Choose a color',
     sort: 'Sort Cards',
+    noSpecialFinish: 'You cannot finish with a special card',
     colors: { red: 'Red', yellow: 'Yellow', green: 'Green', blue: 'Blue', wild: 'Wild' },
     values: { skip: 'Skip', reverse: 'Reverse', draw2: 'Draw 2', wild: 'Wild', wild4: 'Wild +4', swap: 'Swap Hands' },
     viewing: 'Viewing',
@@ -69,6 +70,7 @@ const translations = {
     nameTaken: 'Bu isim zaten kullanılıyor',
     chooseColor: 'Renk seçin',
     sort: 'Kartları sırala',
+    noSpecialFinish: 'Özel kart ile oyunu bitiremezsiniz',
     colors: { red: 'Kırmızı', yellow: 'Sarı', green: 'Yeşil', blue: 'Mavi', wild: 'Özel' },
     values: { skip: 'Atla', reverse: 'Yön Değiştir', draw2: 'Çek 2', wild: 'Joker', wild4: 'Çek 4 Joker', swap: 'El Değiştir' },
     viewing: 'İzlenen',
@@ -145,11 +147,18 @@ function App() {
     });
     socket.on('lobbies', setLobbies);
     socket.on('joinError', joinErrorHandler);
+    const actionErrorHandler = msg => {
+      if (msg === 'specialFinish') showToast(t('noSpecialFinish'));
+      else showToast(t('invalidMove'));
+      setActionPending(false);
+    };
+    socket.on('actionError', actionErrorHandler);
     return () => {
       socket.off('connect');
       socket.off('state');
       socket.off('lobbies');
       socket.off('joinError', joinErrorHandler);
+      socket.off('actionError', actionErrorHandler);
     };
   }, [lang, t]);
 
@@ -230,6 +239,10 @@ function App() {
     const canPlay = card.color === 'wild' || card.color === top.color || card.value === top.value;
     if (!canPlay) {
       showToast(t('invalidMove'));
+      return;
+    }
+    if (hand.length === 1 && typeof card.value !== 'number') {
+      showToast(t('noSpecialFinish'));
       return;
     }
     if (card.color === 'wild') {
@@ -390,11 +403,11 @@ function App() {
           ))}
         </div>
         {!spectator && (
-          <>
-            <button onClick={draw} disabled={!myTurn || actionPending}>{t('draw')}</button>
-            <button onClick={sortHand}>{t('sort')}</button>
-            <button onClick={leaveGame}>{t('leave')}</button>
-          </>
+          <div className="game-actions">
+            <button className="draw-btn" onClick={draw} disabled={!myTurn || actionPending}>{t('draw')}</button>
+            <button className="sort-btn" onClick={sortHand}>{t('sort')}</button>
+            <button className="leave-btn" onClick={leaveGame}>{t('leave')}</button>
+          </div>
         )}
         <h3>{t('players')}</h3>
         <ul className="players">

--- a/server/index.js
+++ b/server/index.js
@@ -51,10 +51,13 @@ io.on('connection', socket => {
 
   socket.on('play', ({ room, card, target }) => {
     const game = games[room];
-    if (game && game.play(socket.id, card, target)) {
+    const result = game && game.play(socket.id, card, target);
+    if (result === true) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);
       if (!game.started) io.emit('lobbies', getLobbies());
+    } else if (result === 'specialFinish') {
+      socket.emit('actionError', 'specialFinish');
     }
   });
 

--- a/server/uno.js
+++ b/server/uno.js
@@ -118,6 +118,9 @@ class Game {
     const idx = player.hand.findIndex(c => c.color === card.color && c.value === card.value);
     if (idx === -1 || !this.canPlay(card)) return false;
 
+    const isSpecial = card.color === 'wild' || typeof card.value !== 'number';
+    if (player.hand.length === 1 && isSpecial) return 'specialFinish';
+
     player.hand.splice(idx, 1);
     if (card.color === 'wild' && card.chosenColor) {
       this.discard.push({ color: card.chosenColor, value: card.value });
@@ -189,7 +192,19 @@ class Game {
     const playable = player.hand.filter(c => c && this.canPlay(c));
     if (playable.length) {
       playable.sort((a, b) => (priority[b.value] || 0) - (priority[a.value] || 0));
-      const card = playable[0];
+      let card = playable[0];
+      if (player.hand.length === 1 && (card.color === 'wild' || typeof card.value !== 'number')) {
+        const numeric = playable.find(c => typeof c.value === 'number');
+        if (numeric) {
+          card = numeric;
+        } else {
+          player.hand.push(this.drawCard());
+          this.nextTurn();
+          io.to(room).emit('state', this.getState());
+          if (this.started) this.checkAI(io, room);
+          return;
+        }
+      }
       const idx = player.hand.findIndex(c => c === card);
       player.hand.splice(idx, 1);
       if (card.color === 'wild') {


### PR DESCRIPTION
## Summary
- Prevent finishing the game with a special card and notify the player
- Redesign action buttons, player list, color picker and toasts for a nicer look
- Adjust mobile layout and viewport for better small-screen experience

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a16acdf1d48327b420649294f80acb