### PR TITLE
Add invite link, spectators, chat and admin utilities

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -253,13 +253,80 @@
   border-radius: 6px;
 }
 
+.spectators li {
+  background: rgba(0,0,0,0.2);
+}
+
+.share-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  margin-left: 0.5rem;
+}
+
+.chat-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.chat-box {
+  position: fixed;
+  bottom: 3rem;
+  right: 1rem;
+  width: 200px;
+  max-height: 200px;
+  background: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  font-size: 0.75rem;
+}
+
+.chat-input input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.admin-badge {
+  margin-left: 0.5rem;
+  background: red;
+  color: #fff;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.empty-btn {
+  margin-left: 1rem;
+  padding: 0.3rem 0.6rem;
+}
+
 .app-title:hover::after {
   opacity: 1;
 }
 
 .app-footer {
   margin-top: 2rem;
-  font-size: 0.9rem;
+  font-size: 0.7rem;
+  opacity: 0.5;
+  position: fixed;
+  bottom: 0.3rem;
+  left: 0;
+  width: 100%;
+  text-align: center;
 }
 
 .color-picker {
@@ -336,4 +403,20 @@
   0% { transform: translate(-50%, -50%) scale(0.5); opacity: 0; }
   60% { transform: translate(-50%, -50%) scale(1.1); opacity: 1; }
   100% { transform: translate(-50%, -50%) scale(1); }
+}
+
+@media (max-width: 600px) {
+  .join, .lobby, .game {
+    margin: 1rem;
+    padding: 1rem;
+  }
+  .top-area {
+    margin-bottom: 0.5rem;
+  }
+  .top-area h2, .game h3 {
+    font-size: 1rem;
+  }
+  .app-header {
+    margin: 0.5rem 0;
+  }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,6 +21,7 @@ const translations = {
     yourTurn: '(Your turn)',
     draw: 'Draw',
     players: 'Players',
+    spectators: 'Spectators',
     turn: 'Turn',
     cards: 'cards',
     roomExists: 'Room already exists',
@@ -47,6 +48,8 @@ const translations = {
     wins: 'wins!',
     choosePlayer: 'Choose a player',
     activeLobbies: 'Active Lobbies',
+    chat: 'Chat',
+    emptyRooms: 'Empty All Rooms',
   },
   tr: {
     joinGame: 'Oyuna Katıl',
@@ -61,6 +64,7 @@ const translations = {
     yourTurn: '(Sıra sizde)',
     draw: 'Kart Çek',
     players: 'Oyuncular',
+    spectators: 'İzleyiciler',
     turn: 'Sıra',
     cards: 'kart',
     roomExists: 'Oda zaten mevcut',
@@ -87,13 +91,17 @@ const translations = {
     wins: 'kazandı!',
     choosePlayer: 'Bir oyuncu seçin',
     activeLobbies: 'Aktif Lobbiler',
+    chat: 'Sohbet',
+    emptyRooms: 'Tüm Odaları Boşalt',
   },
 };
 
 function App() {
   const [id, setId] = useState('');
   const [name, setName] = useState('');
-  const [room, setRoom] = useState('lobby');
+  const params = new URLSearchParams(window.location.search);
+  const initialRoom = params.get('room') || 'lobby';
+  const [room, setRoom] = useState(initialRoom);
   const [joined, setJoined] = useState(false);
   const [state, setState] = useState(null);
   const [ai, setAi] = useState(false);
@@ -111,6 +119,11 @@ function App() {
   const [watching, setWatching] = useState(null);
   const [follow, setFollow] = useState(true);
   const [sorted, setSorted] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [chatMsg, setChatMsg] = useState('');
+  const [admin, setAdmin] = useState(false);
+  const [titleClicks, setTitleClicks] = useState(0);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
@@ -147,6 +160,7 @@ function App() {
     });
     socket.on('lobbies', setLobbies);
     socket.on('joinError', joinErrorHandler);
+    socket.on('chat', msg => setMessages(m => [...m, msg]));
     const actionErrorHandler = msg => {
       if (msg === 'specialFinish') showToast(t('noSpecialFinish'));
       else showToast(t('invalidMove'));
@@ -159,6 +173,7 @@ function App() {
       socket.off('lobbies');
       socket.off('joinError', joinErrorHandler);
       socket.off('actionError', actionErrorHandler);
+      socket.off('chat');
     };
   }, [lang, t]);
 
@@ -213,6 +228,38 @@ function App() {
 
   const start = () => {
     socket.emit('start', { room, ai });
+  };
+
+  const shareRoom = (r) => {
+    const link = `${window.location.origin}?room=${r}`;
+    if (navigator.share) {
+      navigator.share({ url: link });
+    } else {
+      navigator.clipboard.writeText(link);
+      showToast(link);
+    }
+  };
+
+  const sendChat = (e) => {
+    e.preventDefault();
+    if (!chatMsg) return;
+    socket.emit('chat', { room, name, message: chatMsg });
+    setChatMsg('');
+  };
+
+  const handleTitleClick = () => {
+    setTitleClicks(c => {
+      const nc = c + 1;
+      if (nc >= 5) {
+        setAdmin(a => !a);
+        return 0;
+      }
+      return nc;
+    });
+  };
+
+  const emptyRooms = () => {
+    socket.emit('emptyRooms');
   };
 
   const performPlay = (card, idx, target) => {
@@ -305,16 +352,22 @@ function App() {
 
   useEffect(() => {
     const saved = localStorage.getItem('unoGame');
+    const urlRoom = params.get('room');
     if (saved) {
       try {
         const { room: savedRoom, name: savedName } = JSON.parse(saved);
         setName(savedName);
-        setRoom(savedRoom);
-        socket.emit('join', { room: savedRoom, name: savedName });
-        setJoined(true);
+        const joinRoom = urlRoom || savedRoom;
+        if (joinRoom && savedName) {
+          setRoom(joinRoom);
+          socket.emit('join', { room: joinRoom, name: savedName });
+          setJoined(true);
+        }
       } catch {
         // ignore parsing errors
       }
+    } else if (urlRoom) {
+      setRoom(urlRoom);
     }
   }, []);
 
@@ -350,7 +403,7 @@ function App() {
   } else if (!state || !state.started) {
     content = (
       <div className="lobby">
-        <h2>{t('roomHeading')}: {room}</h2>
+        <h2>{t('roomHeading')}: {room} <button className="share-btn" onClick={() => shareRoom(room)}>🔗</button></h2>
         {state?.winner && <h3>{t('winner')}: {state.players.find(p => p.id === state.winner)?.name}</h3>}
         <ul>
           {state?.players.map(p => <li key={p.id}>{p.name}</li>)}
@@ -375,7 +428,7 @@ function App() {
           </div>
           <span className="top-label">{colorText(state.top.color)} {displayValue(state.top.value)}</span>
         </div>
-        <h3>{t('turn')}: {state.players.find(p => p.id === state.current)?.name}</h3>
+        <h3>{t('turn')}: {state.players.find(p => p.id === state.current)?.name} <button className="share-btn" onClick={() => shareRoom(room)}>🔗</button></h3>
         {spectator ? (
           <>
             <h3>{t('viewing')}: {viewingPlayer?.name}</h3>
@@ -421,13 +474,25 @@ function App() {
             </li>
           ))}
         </ul>
+        {state.spectators?.length > 0 && (
+          <>
+            <h3>{t('spectators')}</h3>
+            <ul className="players spectators">
+              {state.spectators.map(s => (
+                <li key={s.id}>{s.name}</li>
+              ))}
+            </ul>
+          </>
+        )}
       </div>
     );
   }
   return (
     <>
       <header className="app-header">
-        <h1 className="app-title" data-version={pkg.version} title={pkg.version}>{lang === 'tr' ? 'Uno Oyunu' : 'Uno Game'}</h1>
+        <h1 className="app-title" data-version={pkg.version} title={pkg.version} onClick={handleTitleClick}>{lang === 'tr' ? 'Uno Oyunu' : 'Uno Game'}</h1>
+        {admin && <span className="admin-badge">ADMIN</span>}
+        {admin && <button className="empty-btn" onClick={emptyRooms}>{t('emptyRooms')}</button>}
       </header>
       {content}
       {colorPicker && (
@@ -458,6 +523,19 @@ function App() {
         </div>
       )}
       {toast && <div className="toast">{toast}</div>}
+      <button className="chat-toggle" onClick={() => setChatOpen(o => !o)}>💬</button>
+      {chatOpen && (
+        <div className="chat-box">
+          <div className="chat-messages">
+            {messages.map((m, i) => (
+              <div key={i}><strong>{m.name}:</strong> {m.message}</div>
+            ))}
+          </div>
+          <form onSubmit={sendChat} className="chat-input">
+            <input value={chatMsg} onChange={e => setChatMsg(e.target.value)} />
+          </form>
+        </div>
+      )}
       <footer className="app-footer">{t('developedBy')}</footer>
     </>
   );

--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,11 @@ io.on('connection', socket => {
       return socket.emit('joinError', 'nameTaken');
     }
     if (!game.addPlayer(socket.id, name)) {
-      return socket.emit('joinError', 'notfound');
+      if (game.started) {
+        game.addSpectator(socket.id, name);
+      } else {
+        return socket.emit('joinError', 'notfound');
+      }
     }
     socket.join(room);
     io.to(room).emit('state', game.getState());
@@ -72,10 +76,16 @@ io.on('connection', socket => {
 
   socket.on('leave', ({ room }) => {
     const game = games[room];
-    if (game && game.replaceWithAI(socket.id)) {
-      socket.leave(room);
-      io.to(room).emit('state', game.getState());
-      game.checkAI(io, room);
+    if (game) {
+      if (game.replaceWithAI(socket.id)) {
+        socket.leave(room);
+        io.to(room).emit('state', game.getState());
+        game.checkAI(io, room);
+      } else {
+        game.removeSpectator(socket.id);
+        socket.leave(room);
+        io.to(room).emit('state', game.getState());
+      }
     }
     io.emit('lobbies', getLobbies());
   });
@@ -84,12 +94,25 @@ io.on('connection', socket => {
     Object.keys(games).forEach(room => {
       const game = games[room];
       game.disconnectPlayer(socket.id);
+      game.removeSpectator(socket.id);
       if (game.isEmpty()) {
         delete games[room];
       } else {
         io.to(room).emit('state', game.getState());
         game.checkAI(io, room);
       }
+    });
+    io.emit('lobbies', getLobbies());
+  });
+
+  socket.on('chat', ({ room, name, message }) => {
+    io.to(room).emit('chat', { name, message });
+  });
+
+  socket.on('emptyRooms', () => {
+    Object.keys(games).forEach(r => {
+      io.to(r).emit('state', { started: false, players: [], spectators: [], current: null, top: null, winner: null });
+      delete games[r];
     });
     io.emit('lobbies', getLobbies());
   });

--- a/server/uno.js
+++ b/server/uno.js
@@ -27,6 +27,7 @@ class Game {
   constructor(room) {
     this.room = room;
     this.players = [];
+    this.spectators = [];
     this.turn = 0;
     this.direction = 1;
     this.started = false;
@@ -59,8 +60,17 @@ class Game {
     this.players = this.players.filter(p => p.id !== id);
   }
 
+  addSpectator(id, name) {
+    if (this.spectators.find(s => s.id === id)) return;
+    this.spectators.push({ id, name });
+  }
+
+  removeSpectator(id) {
+    this.spectators = this.spectators.filter(s => s.id !== id);
+  }
+
   isEmpty() {
-    return this.players.every(p => !p.id);
+    return this.players.every(p => !p.id) && this.spectators.length === 0;
   }
 
   start(ai = false) {
@@ -260,6 +270,7 @@ class Game {
     return {
       started: this.started,
       players: this.players.map(p => ({ id: p.id, name: p.name, hand: p.hand })),
+      spectators: this.spectators.map(s => ({ id: s.id, name: s.name })),
       current: this.currentPlayer() ? this.currentPlayer().id : null,
       top: this.discard[this.discard.length - 1],
       winner: this.winner


### PR DESCRIPTION
## Summary
- Allow inviting players via shareable room links
- Support spectators and display them separately
- Add compact chat, admin mode toggle and room reset
- Improve mobile layout and footer styling

## Testing
- `npm test` (server) – No tests
- `npm test` (client) – No tests

------
https://chatgpt.com/codex/tasks/task_e_68a17cfd5cc483279ed84bf1c9f2cebe