### PR TITLE
Highlight playable cards, tighten board spacing, and improve chat UI

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,6 +1,6 @@
 .join, .lobby, .game {
   text-align: center;
-  margin: 2rem;
+  margin: 1rem 2rem;
   padding: 2rem;
   border-radius: 1rem;
   background: rgba(0, 0, 0, 0.3);
@@ -68,6 +68,14 @@
 .card:disabled {
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+.card.playable {
+  filter: brightness(1.15);
+}
+
+.card.unplayable {
+  filter: brightness(0.7);
 }
 
 .card .tooltip {
@@ -182,8 +190,8 @@
 }
 
 .app-header {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .app-title {
@@ -424,7 +432,7 @@
 
 @media (max-width: 600px) {
   .join, .lobby, .game {
-    margin: 1rem;
+    margin: 0.5rem;
     padding: 1rem;
   }
   .top-area {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { io } from 'socket.io-client';
 import './App.css';
 import pkg from '../package.json';
@@ -129,6 +129,8 @@ function App() {
   const [chatMsg, setChatMsg] = useState('');
   const [admin, setAdmin] = useState(false);
   const [, setTitleClicks] = useState(0);
+  const chatBoxRef = useRef(null);
+  const chatToggleRef = useRef(null);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
@@ -165,7 +167,10 @@ function App() {
     });
     socket.on('lobbies', setLobbies);
     socket.on('joinError', joinErrorHandler);
-    socket.on('chat', msg => setMessages(m => [...m, msg]));
+    socket.on('chat', msg => {
+      setMessages(m => [...m, msg]);
+      showToast(`${msg.name}: ${msg.message}`);
+    });
     const actionErrorHandler = msg => {
       if (msg === 'specialFinish') showToast(t('noSpecialFinish'));
       else showToast(t('invalidMove'));
@@ -254,7 +259,24 @@ function App() {
     if (!chatMsg.trim()) return;
     socket.emit('chat', { room, name, message: chatMsg });
     setChatMsg('');
+    setChatOpen(false);
   };
+
+  useEffect(() => {
+    if (!chatOpen) return;
+    const handleClickOutside = (e) => {
+      if (
+        chatBoxRef.current &&
+        !chatBoxRef.current.contains(e.target) &&
+        chatToggleRef.current &&
+        !chatToggleRef.current.contains(e.target)
+      ) {
+        setChatOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [chatOpen]);
 
   const handleTitleClick = () => {
     setTitleClicks(c => {
@@ -463,25 +485,29 @@ function App() {
           <h3>{t('yourHand')} {myTurn ? t('yourTurn') : ''}</h3>
         )}
         <div className="hand">
-          {displayHand.map((c, idx) => (
-            <button
-              key={idx}
-              className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''}`}
-              onClick={spectator ? undefined : () => play(c, idx)}
-              disabled={spectator || !myTurn || actionPending}
-              draggable={!spectator}
-              onDragStart={spectator ? undefined : () => onDragStart(idx)}
-              onDragOver={spectator ? undefined : e => e.preventDefault()}
-              onDrop={spectator ? undefined : () => onDrop(idx)}
-              aria-label={`${colorText(c.color)} ${valueText(c.value)}`}
-            >
-              {cardIcons[c.value] || c.value}
-              {newCards.includes(JSON.stringify(c)) && myTurn && (
-                <span className="new-badge">{t('new')}</span>
-              )}
-              <span className="tooltip">{`${colorText(c.color)} ${displayValue(c.value)}`}</span>
-            </button>
-          ))}
+          {displayHand.map((c, idx) => {
+            const canPlayCard = c.color === 'wild' || c.color === state.top.color || c.value === state.top.value;
+            const playClass = myTurn ? (canPlayCard ? 'playable' : 'unplayable') : '';
+            return (
+              <button
+                key={idx}
+                className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''} ${playClass}`}
+                onClick={spectator ? undefined : () => play(c, idx)}
+                disabled={spectator || !myTurn || actionPending}
+                draggable={!spectator}
+                onDragStart={spectator ? undefined : () => onDragStart(idx)}
+                onDragOver={spectator ? undefined : e => e.preventDefault()}
+                onDrop={spectator ? undefined : () => onDrop(idx)}
+                aria-label={`${colorText(c.color)} ${valueText(c.value)}`}
+              >
+                {cardIcons[c.value] || c.value}
+                {newCards.includes(JSON.stringify(c)) && myTurn && (
+                  <span className="new-badge">{t('new')}</span>
+                )}
+                <span className="tooltip">{`${colorText(c.color)} ${displayValue(c.value)}`}</span>
+              </button>
+            );
+          })}
         </div>
         {!spectator && (
           <div className="game-actions">
@@ -565,9 +591,15 @@ function App() {
         </div>
       )}
       {toast && <div className="toast">{toast}</div>}
-      <button className="chat-toggle" onClick={() => setChatOpen(o => !o)}>💬</button>
+      <button
+        className="chat-toggle"
+        onClick={() => setChatOpen(o => !o)}
+        ref={chatToggleRef}
+      >
+        💬
+      </button>
       {chatOpen && (
-        <div className="chat-box">
+        <div className="chat-box" ref={chatBoxRef}>
           <div className="chat-messages">
             {messages.map((m, i) => (
               <div key={i}><strong>{m.name}:</strong> {m.message}</div>


### PR DESCRIPTION
## Summary
- Make playable cards brighter and unplayable cards dim when it's your turn
- Reduce spacing between the Uno Game title and the board
- Auto-close chat on send or outside clicks and display chat messages as toast notifications

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm test` (server)
- `npm run lint` (server)`

------
https://chatgpt.com/codex/tasks/task_e_68a188eaba1c83279a0968180a3a8390