### PR TITLE
Refine Turkish labels and initial card indicators

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -64,7 +64,7 @@ const translations = {
     join: 'Katıl',
     roomHeading: 'Oda',
     start: 'Başlat',
-    topCard: 'Üst Kart',
+    topCard: 'Üstteki kart',
     yourHand: 'Eliniz',
     yourTurn: '(Sıra sizde)',
     draw: 'Kart Çek',
@@ -77,7 +77,7 @@ const translations = {
     invalidMove: 'Geçersiz hamle',
     notYourTurn: 'Sıra sizde değil',
     nameTaken: 'Bu isim zaten kullanılıyor',
-    chooseColor: 'Renk seçin',
+    chooseColor: 'Renk seçiniz',
     noSpecialFinish: 'Özel kart ile oyunu bitiremezsiniz',
     colors: { red: 'Kırmızı', yellow: 'Sarı', green: 'Yeşil', blue: 'Mavi', wild: 'Özel' },
     values: { skip: 'Atla', reverse: 'Yön Değiştir', draw2: 'Çek 2', wild: 'Joker', wild4: 'Çek 4 Joker', swap: 'El Değiştir' },
@@ -210,7 +210,7 @@ function App() {
               newOnes.push(key);
             }
           });
-          if (newOnes.length) {
+          if (prev.length !== 0 && newOnes.length) {
             setNewCards(cards => Array.from(new Set([...cards, ...newOnes])));
           }
           return sortedHand;
@@ -568,9 +568,12 @@ function App() {
           <p>{t('chooseColor')}</p>
           <div className="color-options">
             {COLORS.map(c => (
-              <button key={c} className={`color-btn ${c}`} onClick={() => chooseColor(c)}>
-                {colorText(c)}
-              </button>
+              <button
+                key={c}
+                className={`color-btn ${c}`}
+                onClick={() => chooseColor(c)}
+                aria-label={colorText(c)}
+              />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Show "Renk seçiniz" prompt above wild-card color picker with icon-only buttons
- Use "Üstteki kart" instead of "Üst Kart" in Turkish translation
- Skip showing the "New" badge on the initially dealt hand

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm test` (server)`

------
https://chatgpt.com/codex/tasks/task_e_68a18d0da9bc83279ec60fe858b62b7f