### PR TITLE
Add stacking and multi-card play options with selectable cards

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -78,6 +78,10 @@
   filter: brightness(0.7);
 }
 
+.card.selected {
+  transform: translateY(-15px);
+}
+
 .card .tooltip {
   visibility: hidden;
   background: rgba(0, 0, 0, 0.8);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -55,6 +55,8 @@ const translations = {
     chat: 'Chat',
     emptyRooms: 'Empty All Rooms',
     new: 'New',
+    stacking: 'Stacking',
+    multiPlay: 'Multi Play',
   },
   tr: {
     joinGame: 'Oyuna Katıl',
@@ -100,6 +102,8 @@ const translations = {
     chat: 'Sohbet',
     emptyRooms: 'Tüm Odaları Boşalt',
     new: 'Yeni',
+    stacking: 'Katlama',
+    multiPlay: 'Çoklu Oynama',
   },
 };
 
@@ -131,6 +135,9 @@ function App() {
   const [, setTitleClicks] = useState(0);
   const chatBoxRef = useRef(null);
   const chatToggleRef = useRef(null);
+  const [selected, setSelected] = useState([]);
+  const [stacking, setStacking] = useState(true);
+  const [multi, setMulti] = useState(true);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
@@ -163,6 +170,10 @@ function App() {
     socket.on('connect', () => setId(socket.id));
     socket.on('state', st => {
       setState(st);
+      if (!st.started && st.options) {
+        setStacking(st.options.stacking);
+        setMulti(st.options.multi);
+      }
       setActionPending(false);
     });
     socket.on('lobbies', setLobbies);
@@ -241,7 +252,7 @@ function App() {
   };
 
   const start = () => {
-    socket.emit('start', { room, ai });
+    socket.emit('start', { room, ai, options: { stacking, multi } });
   };
 
   const shareRoom = (r) => {
@@ -293,67 +304,98 @@ function App() {
     socket.emit('emptyRooms');
   };
 
-  const performPlay = (card, idx, target) => {
+  const performPlay = (cards, indices, target) => {
     setActionPending(true);
-    setPlayingIndex(idx);
+    setPlayingIndex(indices[0]);
     setTimeout(() => {
       setHand(h => {
         const newHand = [...h];
-        newHand.splice(idx, 1);
+        indices.sort((a, b) => b - a).forEach(i => newHand.splice(i, 1));
         return newHand;
       });
-      socket.emit('play', { room, card, target });
+      setNewCards(cn => {
+        const updated = [...cn];
+        cards.forEach(card => {
+          const key = JSON.stringify(card);
+          const idx = updated.indexOf(key);
+          if (idx !== -1) updated.splice(idx, 1);
+        });
+        return updated;
+      });
+      socket.emit('play', { room, cards, target });
       setPlayingIndex(null);
+      setSelected([]);
     }, 400);
   };
 
-  const play = (card, idx) => {
+  const attemptPlay = () => {
     if (!myTurn) {
       showToast(t('notYourTurn'));
       return;
     }
     if (actionPending) return;
+    if (!selected.length) return;
+    const cardsToPlay = selected.map(i => hand[i]);
+    const first = cardsToPlay[0];
     const top = state.top;
-    const canPlay = card.color === 'wild' || card.color === top.color || card.value === top.value;
+    const canPlay = first.color === 'wild' || first.color === top.color || first.value === top.value;
     if (!canPlay) {
       showToast(t('invalidMove'));
+      setSelected([]);
       return;
     }
-    if (hand.length === 1 && typeof card.value !== 'number') {
+    if (!cardsToPlay.every(c => c.value === first.value)) {
+      showToast(t('invalidMove'));
+      setSelected([]);
+      return;
+    }
+    if (!state?.options?.multi && cardsToPlay.length > 1) {
+      showToast(t('invalidMove'));
+      setSelected([]);
+      return;
+    }
+    if (hand.length === cardsToPlay.length && cardsToPlay.some(c => typeof c.value !== 'number')) {
       showToast(t('noSpecialFinish'));
+      setSelected([]);
       return;
     }
-    setNewCards(cards => {
-      const key = JSON.stringify(card);
-      const idx = cards.indexOf(key);
-      if (idx === -1) return cards;
-      const updated = [...cards];
-      updated.splice(idx, 1);
-      return updated;
-    });
-    if (card.color === 'wild') {
-      setColorPicker({ card, idx });
+    if (first.color === 'wild') {
+      setColorPicker({ cards: cardsToPlay, indices: selected });
       return;
     }
-    performPlay(card, idx);
+    performPlay(cardsToPlay, selected);
+  };
+
+  const handleCardClick = (card, idx) => {
+    if (selected.includes(idx)) {
+      attemptPlay();
+    } else {
+      setSelected(prev => {
+        if (prev.length && (!state?.options?.multi || hand[prev[0]].value !== card.value)) {
+          return [idx];
+        }
+        return [...prev, idx];
+      });
+    }
   };
 
   const chooseColor = (color) => {
     if (!colorPicker) return;
-    const { card, idx } = colorPicker;
+    const { cards, indices } = colorPicker;
     setColorPicker(null);
-    if (card.value === 'swap') {
-      setSwapPicker({ card: { ...card, chosenColor: color }, idx });
+    const updated = cards.map((c, i) => i === 0 ? { ...c, chosenColor: color } : c);
+    if (cards[0].value === 'swap') {
+      setSwapPicker({ cards: updated, indices });
     } else {
-      performPlay({ ...card, chosenColor: color }, idx);
+      performPlay(updated, indices);
     }
   };
 
   const chooseSwapTarget = (targetId) => {
     if (!swapPicker) return;
-    const { card, idx } = swapPicker;
+    const { cards, indices } = swapPicker;
     setSwapPicker(null);
-    performPlay(card, idx, targetId);
+    performPlay(cards, indices, targetId);
   };
 
   const draw = () => {
@@ -363,6 +405,7 @@ function App() {
     }
     if (actionPending) return;
     setActionPending(true);
+    setSelected([]);
     socket.emit('draw', { room });
   };
 
@@ -456,6 +499,14 @@ function App() {
           <input type="checkbox" checked={ai} onChange={e => setAi(e.target.checked)} />
           {t('addComputer')}
         </label>
+        <label>
+          <input type="checkbox" checked={stacking} onChange={e => setStacking(e.target.checked)} />
+          {t('stacking')}
+        </label>
+        <label>
+          <input type="checkbox" checked={multi} onChange={e => setMulti(e.target.checked)} />
+          {t('multiPlay')}
+        </label>
         <button onClick={start}>{t('start')}</button>
       </div>
     );
@@ -498,15 +549,22 @@ function App() {
         <div className="hand">
           {displayHand.map((c, idx) => {
             const key = JSON.stringify(c);
-            const canPlayCard = c.color === 'wild' || c.color === state.top.color || c.value === state.top.value;
+            const canPlayCard = (() => {
+              const top = state.top;
+              if (state.pendingDraw > 0) {
+                if (top.value === 'draw2') return c.value === 'draw2';
+                if (top.value === 'wild4') return c.value === 'wild4';
+              }
+              return c.color === 'wild' || c.color === state.top.color || c.value === state.top.value;
+            })();
             const playClass = myTurn ? (canPlayCard ? 'playable' : 'unplayable') : '';
             const isNew = myTurn && newCounts[key] > 0;
             if (isNew) newCounts[key]--;
             return (
               <button
                 key={idx}
-                className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''} ${playClass}`}
-                onClick={spectator ? undefined : () => play(c, idx)}
+                className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''} ${playClass} ${selected.includes(idx) ? 'selected' : ''}`}
+                onClick={spectator ? undefined : () => handleCardClick(c, idx)}
                 disabled={spectator || !myTurn || actionPending}
                 draggable={!spectator}
                 onDragStart={spectator ? undefined : () => onDragStart(idx)}

--- a/server/index.js
+++ b/server/index.js
@@ -44,18 +44,18 @@ io.on('connection', socket => {
     io.emit('lobbies', getLobbies());
   });
 
-  socket.on('start', ({ room, ai }) => {
+  socket.on('start', ({ room, ai, options }) => {
     const game = games[room];
-    if (game && game.start(ai)) {
+    if (game && game.start(ai, options)) {
       io.to(room).emit('state', game.getState());
       io.emit('lobbies', getLobbies());
       game.checkAI(io, room);
     }
   });
 
-  socket.on('play', ({ room, card, target }) => {
+  socket.on('play', ({ room, cards, card, target }) => {
     const game = games[room];
-    const result = game && game.play(socket.id, card, target);
+    const result = game && game.play(socket.id, cards || card, target);
     if (result === true) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);

--- a/server/uno.js
+++ b/server/uno.js
@@ -35,6 +35,8 @@ class Game {
     this.deck = [];
     this.ai = null;
     this.winner = null;
+    this.pendingDraw = 0;
+    this.options = { stacking: true, multi: true };
   }
 
   addPlayer(id, name) {
@@ -73,8 +75,10 @@ class Game {
     return this.players.every(p => !p.id) && this.spectators.length === 0;
   }
 
-  start(ai = false) {
+  start(ai = false, options = {}) {
     if (this.players.length < 2 && !ai) return false;
+    this.options = { stacking: true, multi: true, ...options };
+    this.pendingDraw = 0;
     this.deck = createDeck();
     this.players.forEach(p => {
       p.hand = this.deck.splice(0, 7);
@@ -105,6 +109,10 @@ class Game {
   canPlay(card) {
     if (!card) return false;
     const top = this.discard[this.discard.length - 1];
+    if (this.pendingDraw > 0) {
+      if (top.value === 'draw2') return card.value === 'draw2';
+      if (top.value === 'wild4') return card.value === 'wild4';
+    }
     return (
       card.color === 'wild' ||
       card.color === top.color ||
@@ -121,22 +129,36 @@ class Game {
     return this.deck.pop();
   }
 
-  play(id, card, target) {
+  play(id, cards, target) {
     if (!this.started) return false;
     const player = this.currentPlayer();
     if (player.id !== id) return false;
-    const idx = player.hand.findIndex(c => c.color === card.color && c.value === card.value);
-    if (idx === -1 || !this.canPlay(card)) return false;
 
-    const isSpecial = card.color === 'wild' || typeof card.value !== 'number';
-    if (player.hand.length === 1 && isSpecial) return 'specialFinish';
+    if (!Array.isArray(cards)) cards = [cards];
+    if (!this.options.multi && cards.length > 1) return false;
 
-    player.hand.splice(idx, 1);
-    if (card.color === 'wild' && card.chosenColor) {
-      this.discard.push({ color: card.chosenColor, value: card.value });
-    } else {
-      this.discard.push(card);
-    }
+    const first = cards[0];
+    if (!this.canPlay(first)) return false;
+    if (!cards.every(c => c.value === first.value)) return false;
+
+    const indices = cards.map(card =>
+      player.hand.findIndex(c => c.color === card.color && c.value === card.value)
+    );
+    if (indices.some(i => i === -1)) return false;
+
+    const isSpecial = first.color === 'wild' || typeof first.value !== 'number';
+    if (player.hand.length === cards.length && isSpecial) return 'specialFinish';
+
+    // remove cards from hand
+    indices.sort((a, b) => b - a).forEach(i => player.hand.splice(i, 1));
+
+    cards.forEach((card, i) => {
+      if (card.color === 'wild' && card.chosenColor && i === 0) {
+        this.discard.push({ color: card.chosenColor, value: card.value });
+      } else {
+        this.discard.push(card);
+      }
+    });
 
     if (player.hand.length === 0) {
       this.started = false;
@@ -144,7 +166,7 @@ class Game {
       return true;
     }
 
-    switch (card.value) {
+    switch (first.value) {
       case 'reverse':
         this.direction *= -1;
         this.nextTurn();
@@ -155,13 +177,25 @@ class Game {
         break;
       case 'draw2':
         this.nextTurn();
-        this.currentPlayer().hand.push(this.drawCard(), this.drawCard());
-        this.nextTurn();
+        if (this.options.stacking) {
+          this.pendingDraw += 2 * cards.length;
+        } else {
+          for (let i = 0; i < 2 * cards.length; i++) {
+            this.currentPlayer().hand.push(this.drawCard());
+          }
+          this.nextTurn();
+        }
         break;
       case 'wild4':
         this.nextTurn();
-        this.currentPlayer().hand.push(this.drawCard(), this.drawCard(), this.drawCard(), this.drawCard());
-        this.nextTurn();
+        if (this.options.stacking) {
+          this.pendingDraw += 4 * cards.length;
+        } else {
+          for (let i = 0; i < 4 * cards.length; i++) {
+            this.currentPlayer().hand.push(this.drawCard());
+          }
+          this.nextTurn();
+        }
         break;
       case 'swap':
         if (target) {
@@ -181,7 +215,11 @@ class Game {
     if (!this.started) return false;
     const player = this.currentPlayer();
     if (player.id !== id) return false;
-    player.hand.push(this.drawCard());
+    const count = this.pendingDraw > 0 ? this.pendingDraw : 1;
+    for (let i = 0; i < count; i++) {
+      player.hand.push(this.drawCard());
+    }
+    this.pendingDraw = 0;
     this.nextTurn();
     return true;
   }
@@ -205,62 +243,24 @@ class Game {
       let card = playable[0];
       if (player.hand.length === 1 && (card.color === 'wild' || typeof card.value !== 'number')) {
         const numeric = playable.find(c => typeof c.value === 'number');
-        if (numeric) {
-          card = numeric;
-        } else {
-          player.hand.push(this.drawCard());
-          this.nextTurn();
+        if (numeric) card = numeric;
+        else {
+          this.draw(player.id);
           io.to(room).emit('state', this.getState());
           if (this.started) this.checkAI(io, room);
           return;
         }
       }
-      const idx = player.hand.findIndex(c => c === card);
-      player.hand.splice(idx, 1);
       if (card.color === 'wild') {
         const colorCounts = COLORS.map(color => ({
           color,
           count: player.hand.filter(c => c.color === color).length,
         })).sort((a, b) => b.count - a.count);
-        this.discard.push({ color: colorCounts[0].color, value: card.value });
-      } else {
-        this.discard.push(card);
+        card = { ...card, chosenColor: colorCounts[0].color };
       }
-      if (player.hand.length === 0) {
-        this.started = false;
-        this.winner = player.id;
-      } else {
-        switch (card.value) {
-          case 'reverse':
-            this.direction *= -1;
-            this.nextTurn();
-            break;
-          case 'skip':
-            this.nextTurn();
-            this.nextTurn();
-            break;
-          case 'draw2':
-            this.nextTurn();
-            this.currentPlayer().hand.push(this.drawCard(), this.drawCard());
-            this.nextTurn();
-            break;
-          case 'wild4':
-            this.nextTurn();
-            this.currentPlayer().hand.push(this.drawCard(), this.drawCard(), this.drawCard(), this.drawCard());
-            this.nextTurn();
-            break;
-          case 'swap':
-            const target = this.players.filter(p => p.id !== player.id).sort((a, b) => b.hand.length - a.hand.length)[0];
-            if (target) [player.hand, target.hand] = [target.hand, player.hand];
-            this.nextTurn();
-            break;
-          default:
-            this.nextTurn();
-        }
-      }
+      this.play(player.id, card);
     } else {
-      player.hand.push(this.drawCard());
-      this.nextTurn();
+      this.draw(player.id);
     }
     io.to(room).emit('state', this.getState());
     if (this.started) this.checkAI(io, room);
@@ -273,7 +273,9 @@ class Game {
       spectators: this.spectators.map(s => ({ id: s.id, name: s.name })),
       current: this.currentPlayer() ? this.currentPlayer().id : null,
       top: this.discard[this.discard.length - 1],
-      winner: this.winner
+      winner: this.winner,
+      pendingDraw: this.pendingDraw,
+      options: this.options
     };
   }
 }


### PR DESCRIPTION
## Summary
- Allow stacking draw cards and playing multiple cards at once with new game options
- Let players select cards before confirming play, enabling multi-card turns
- Update server and client to track pending draw penalties and expose options in lobby

## Testing
- `npm test --prefix server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68a1af92324483279683b005d745bc1c