### PR TITLE
Limit options to admins and refine card interactions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -289,6 +289,16 @@ function App() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [chatOpen]);
 
+  useEffect(() => {
+    const handleClearSelection = (e) => {
+      if (!e.target.closest('.card')) {
+        setSelected([]);
+      }
+    };
+    document.addEventListener('mousedown', handleClearSelection);
+    return () => document.removeEventListener('mousedown', handleClearSelection);
+  }, []);
+
   const handleTitleClick = () => {
     setTitleClicks(c => {
       const nc = c + 1;
@@ -307,6 +317,7 @@ function App() {
   const performPlay = (cards, indices, target) => {
     setActionPending(true);
     setPlayingIndex(indices[0]);
+    setSelected([]);
     setTimeout(() => {
       setHand(h => {
         const newHand = [...h];
@@ -324,7 +335,6 @@ function App() {
       });
       socket.emit('play', { room, cards, target });
       setPlayingIndex(null);
-      setSelected([]);
     }, 400);
   };
 
@@ -499,14 +509,18 @@ function App() {
           <input type="checkbox" checked={ai} onChange={e => setAi(e.target.checked)} />
           {t('addComputer')}
         </label>
-        <label>
-          <input type="checkbox" checked={stacking} onChange={e => setStacking(e.target.checked)} />
-          {t('stacking')}
-        </label>
-        <label>
-          <input type="checkbox" checked={multi} onChange={e => setMulti(e.target.checked)} />
-          {t('multiPlay')}
-        </label>
+        {admin && (
+          <>
+            <label>
+              <input type="checkbox" checked={stacking} onChange={e => setStacking(e.target.checked)} />
+              {t('stacking')}
+            </label>
+            <label>
+              <input type="checkbox" checked={multi} onChange={e => setMulti(e.target.checked)} />
+              {t('multiPlay')}
+            </label>
+          </>
+        )}
         <button onClick={start}>{t('start')}</button>
       </div>
     );
@@ -554,6 +568,12 @@ function App() {
               if (state.pendingDraw > 0) {
                 if (top.value === 'draw2') return c.value === 'draw2';
                 if (top.value === 'wild4') return c.value === 'wild4';
+              }
+              if (selected.length) {
+                const first = hand[selected[0]];
+                if (selected.includes(idx)) return true;
+                if (!state?.options?.multi) return false;
+                return c.value === first.value;
               }
               return c.color === 'wild' || c.color === state.top.color || c.value === state.top.value;
             })();

--- a/server/uno.js
+++ b/server/uno.js
@@ -39,6 +39,15 @@ class Game {
     this.options = { stacking: true, multi: true };
   }
 
+  nextAIName() {
+    const base = 'Bilgisayar';
+    const names = this.players.map(p => p.name).filter(n => n.startsWith(base));
+    if (!names.length) return base;
+    let n = 2;
+    while (names.includes(`${base} ${n}`)) n++;
+    return `${base} ${n}`;
+  }
+
   addPlayer(id, name) {
     const existing = this.players.find(p => p.name.toLowerCase() === name.toLowerCase());
     if (existing) {
@@ -84,7 +93,7 @@ class Game {
       p.hand = this.deck.splice(0, 7);
     });
     if (ai) {
-      const aiPlayer = { id: `AI-${Date.now()}`, name: 'Bilgisayar', hand: this.deck.splice(0, 7), ai: true };
+      const aiPlayer = { id: `AI-${Date.now()}`, name: this.nextAIName(), hand: this.deck.splice(0, 7), ai: true };
       this.players.push(aiPlayer);
     }
     let first = this.drawCard();
@@ -228,7 +237,7 @@ class Game {
     const player = this.players.find(p => p.id === id);
     if (!player) return false;
     player.id = `AI-${id}`;
-    player.name = `${player.name} (pc)`;
+    player.name = this.nextAIName();
     player.ai = true;
     return true;
   }


### PR DESCRIPTION
## Summary
- Show stacking and multi-play options only in admin mode
- Improve card selection: auto-align after play, recalc playable cards, click outside to clear
- Name multiple AIs sequentially and bump client version

## Testing
- `cd client && npm test`
- `cd ../server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bfc4f8788327aa9c67d7e9d3ac0e