### PR TITLE
Remove top card text and turn share button

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -56,10 +56,6 @@
   margin-bottom: 1rem;
 }
 
-.top-label {
-  font-size: 0.9rem;
-}
-
 .card:hover:not(:disabled) {
   transform: translateY(-10px) scale(1.05) rotate(-3deg);
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.4);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -539,18 +539,9 @@ function App() {
           >
             {cardIcons[state.top.value] || state.top.value}
           </div>
-          <span className="top-label">{colorText(state.top.color)} {displayValue(state.top.value)}</span>
         </div>
         <h3>
-          {t('turn')}: {state.players.find(p => p.id === state.current)?.name}{' '}
-          <button
-            className="share-btn"
-            onClick={() => shareRoom(room)}
-            title={t('shareGame')}
-            aria-label={t('shareGame')}
-          >
-            📤
-          </button>
+          {t('turn')}: {state.players.find(p => p.id === state.current)?.name}
         </h3>
         {spectator ? (
           <>


### PR DESCRIPTION
## Summary
- Remove descriptive label beneath top card
- Drop share button from current turn header
- Clean up unused top-label CSS

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c1362fc08327bd04d790196eef3e