### PR TITLE
Enhance card animations and fix selection state

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -54,6 +54,7 @@
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
+  perspective: 600px;
 }
 
 .card:hover:not(:disabled) {
@@ -100,13 +101,23 @@
 }
 
 @keyframes playCard {
-  0% { transform: translateY(0) scale(1); }
-  50% { transform: translateY(-30px) scale(1.1); }
-  100% { transform: translateY(-30px) scale(1); }
+  0% { transform: translateY(0) scale(1) rotate(0deg); box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); }
+  50% { transform: translateY(-30px) scale(1.1) rotate(-15deg); box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5); }
+  100% { transform: translateY(-30px) scale(1) rotate(0deg); box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); }
 }
 
 .card.playing {
-  animation: playCard 0.4s ease forwards;
+  animation: playCard 0.5s ease forwards;
+}
+
+@keyframes flipCard {
+  0% { transform: rotateY(0); }
+  50% { transform: rotateY(90deg); }
+  100% { transform: rotateY(0); }
+}
+
+.card.flipping {
+  animation: flipCard 0.5s ease;
 }
 
 @keyframes fadeIn {
@@ -437,6 +448,7 @@
   }
   .top-area {
     margin-bottom: 0.5rem;
+    perspective: 600px;
   }
   .top-area h2, .game h3 {
     font-size: 1rem;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -138,9 +138,11 @@ function App() {
   const [selected, setSelected] = useState([]);
   const [stacking, setStacking] = useState(true);
   const [multi, setMulti] = useState(true);
+  const [topChanging, setTopChanging] = useState(false);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
+  const topCard = state?.top;
 
   const t = useCallback((key) => translations[lang][key] || key, [lang]);
   const colorText = (color) => translations[lang].colors[color] || color;
@@ -235,6 +237,17 @@ function App() {
       setNewCards([]);
     }
   }, [state, id]);
+
+  useEffect(() => {
+    setSelected([]);
+  }, [hand]);
+
+  useEffect(() => {
+    if (!topCard) return;
+    setTopChanging(true);
+    const timeout = setTimeout(() => setTopChanging(false), 500);
+    return () => clearTimeout(timeout);
+  }, [topCard]);
 
   const joinLobby = (r) => {
     if (!name) return;
@@ -335,7 +348,7 @@ function App() {
       });
       socket.emit('play', { room, cards, target });
       setPlayingIndex(null);
-    }, 400);
+    }, 500);
   };
 
   const attemptPlay = () => {
@@ -534,7 +547,7 @@ function App() {
         <div className="top-area">
           <h2>{t('topCard')}</h2>
           <div
-            className={`card ${state.top.color} small`}
+            className={`card ${state.top.color} small ${topChanging ? 'flipping' : ''}`}
             aria-label={`${colorText(state.top.color)} ${valueText(state.top.value)}`}
           >
             {cardIcons[state.top.value] || state.top.value}


### PR DESCRIPTION
## Summary
- Add special animation when playing a card to the deck
- Animate top card display on change
- Clear card selection when hand changes to avoid stray styling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1cfd2e81c8327825e63c4c2095dd7