### PR TITLE
Improve animations and admin controls

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -48,6 +48,13 @@
   cursor: default;
 }
 
+.card.top {
+  width: 60px;
+  height: 90px;
+  font-size: 1.5rem;
+  cursor: default;
+}
+
 .top-area {
   display: flex;
   flex-direction: column;
@@ -55,6 +62,11 @@
   gap: 0.5rem;
   margin-bottom: 1rem;
   perspective: 600px;
+}
+
+.penalty-info {
+  font-size: 0.9rem;
+  color: #fff;
 }
 
 .card:hover:not(:disabled) {
@@ -101,13 +113,21 @@
 }
 
 @keyframes playCard {
-  0% { transform: translateY(0) scale(1) rotate(0deg); box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); }
-  50% { transform: translateY(-30px) scale(1.1) rotate(-15deg); box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5); }
-  100% { transform: translateY(-30px) scale(1) rotate(0deg); box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); }
+  from { transform: translate(0,0) scale(1); opacity: 1; }
+  to { transform: translate(-40px,-80px) scale(0.8); opacity: 0.5; }
 }
 
 .card.playing {
-  animation: playCard 0.5s ease forwards;
+  animation: playCard 0.8s ease forwards;
+}
+
+@keyframes drawCard {
+  from { transform: translateY(-20px) scale(0.8); opacity: 0; }
+  to { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+.card.drawn {
+  animation: drawCard 0.5s ease;
 }
 
 @keyframes flipCard {
@@ -209,6 +229,10 @@
   position: relative;
   display: inline-block;
   cursor: default;
+  font-family: 'Trebuchet MS', sans-serif;
+  background: linear-gradient(45deg, #e74c3c, #f1c40f, #27ae60, #3498db);
+  -webkit-background-clip: text;
+  color: transparent;
 }
 
 .app-title::after {
@@ -266,6 +290,14 @@
   background: rgba(0, 0, 0, 0.4);
   padding: 0.3rem 0.6rem;
   border-radius: 6px;
+}
+
+.players li .mini-btn {
+  margin-left: 0.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #fff;
 }
 
 .spectators li {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -115,7 +115,7 @@ function App() {
   const [room, setRoom] = useState(initialRoom);
   const [joined, setJoined] = useState(false);
   const [state, setState] = useState(null);
-  const [ai, setAi] = useState(false);
+  const [aiCount, setAiCount] = useState(0);
   const [lang, setLang] = useState('tr');
   const [playingIndex, setPlayingIndex] = useState(null);
   const [hand, setHand] = useState([]);
@@ -265,7 +265,7 @@ function App() {
   };
 
   const start = () => {
-    socket.emit('start', { room, ai, options: { stacking, multi } });
+    socket.emit('start', { room, aiCount, options: { stacking, multi } });
   };
 
   const shareRoom = (r) => {
@@ -348,7 +348,7 @@ function App() {
       });
       socket.emit('play', { room, cards, target });
       setPlayingIndex(null);
-    }, 500);
+    }, 800);
   };
 
   const attemptPlay = () => {
@@ -430,6 +430,14 @@ function App() {
     setActionPending(true);
     setSelected([]);
     socket.emit('draw', { room });
+  };
+
+  const makeComputer = (playerId) => {
+    socket.emit('makeAI', { room, target: playerId });
+  };
+
+  const kickPlayer = (playerId) => {
+    socket.emit('kick', { room, target: playerId });
   };
 
   const onDragStart = (index) => setDragIndex(index);
@@ -519,8 +527,8 @@ function App() {
           {state?.players.map(p => <li key={p.id}>{p.name}</li>)}
         </ul>
         <label>
-          <input type="checkbox" checked={ai} onChange={e => setAi(e.target.checked)} />
           {t('addComputer')}
+          <input type="number" min="0" value={aiCount} onChange={e => setAiCount(parseInt(e.target.value,10) || 0)} />
         </label>
         {admin && (
           <>
@@ -547,11 +555,16 @@ function App() {
         <div className="top-area">
           <h2>{t('topCard')}</h2>
           <div
-            className={`card ${state.top.color} small ${topChanging ? 'flipping' : ''}`}
+            className={`card ${state.top.color} top ${topChanging ? 'flipping' : ''}`}
             aria-label={`${colorText(state.top.color)} ${valueText(state.top.value)}`}
           >
             {cardIcons[state.top.value] || state.top.value}
           </div>
+          {state.pendingDraw > 0 && (
+            <p className="penalty-info">
+              {`${colorText(state.top.color)} ${valueText(state.top.value)} (${state.pendingDraw} ${lang === 'tr' ? 'kart ceza' : 'card penalty'})`}
+            </p>
+          )}
         </div>
         <h3>
           {t('turn')}: {state.players.find(p => p.id === state.current)?.name}
@@ -587,7 +600,7 @@ function App() {
             return (
               <button
                 key={idx}
-                className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''} ${playClass} ${selected.includes(idx) ? 'selected' : ''}`}
+                className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''} ${playClass} ${isNew ? 'drawn' : ''} ${selected.includes(idx) ? 'selected' : ''}`}
                 onClick={spectator ? undefined : () => handleCardClick(c, idx)}
                 disabled={spectator || !myTurn || actionPending}
                 draggable={!spectator}
@@ -635,6 +648,12 @@ function App() {
               onClick={spectator ? () => { setWatching(p.id); setFollow(false); } : undefined}
             >
               {p.name}: {p.hand.length} {t('cards')}
+              {admin && p.id !== id && (
+                <>
+                  <button className="mini-btn" onClick={() => makeComputer(p.id)}>🤖</button>
+                  <button className="mini-btn" onClick={() => kickPlayer(p.id)}>✖️</button>
+                </>
+              )}
             </li>
           ))}
         </ul>

--- a/server/index.js
+++ b/server/index.js
@@ -44,9 +44,9 @@ io.on('connection', socket => {
     io.emit('lobbies', getLobbies());
   });
 
-  socket.on('start', ({ room, ai, options }) => {
+  socket.on('start', ({ room, aiCount, options }) => {
     const game = games[room];
-    if (game && game.start(ai, options)) {
+    if (game && game.start(aiCount, options)) {
       io.to(room).emit('state', game.getState());
       io.emit('lobbies', getLobbies());
       game.checkAI(io, room);
@@ -70,6 +70,27 @@ io.on('connection', socket => {
     if (game && game.draw(socket.id)) {
       io.to(room).emit('state', game.getState());
       game.checkAI(io, room);
+      if (!game.started) io.emit('lobbies', getLobbies());
+    }
+  });
+
+  socket.on('makeAI', ({ room, target }) => {
+    const game = games[room];
+    if (game && game.replaceWithAI(target)) {
+      const targetSocket = io.sockets.sockets.get(target);
+      if (targetSocket) targetSocket.leave(room);
+      io.to(room).emit('state', game.getState());
+      game.checkAI(io, room);
+    }
+  });
+
+  socket.on('kick', ({ room, target }) => {
+    const game = games[room];
+    if (game) {
+      game.removePlayer(target);
+      const targetSocket = io.sockets.sockets.get(target);
+      if (targetSocket) targetSocket.leave(room);
+      io.to(room).emit('state', game.getState());
       if (!game.started) io.emit('lobbies', getLobbies());
     }
   });

--- a/server/uno.js
+++ b/server/uno.js
@@ -84,16 +84,21 @@ class Game {
     return this.players.every(p => !p.id) && this.spectators.length === 0;
   }
 
-  start(ai = false, options = {}) {
-    if (this.players.length < 2 && !ai) return false;
+  start(aiCount = 0, options = {}) {
+    if (this.players.length < 2 && aiCount === 0) return false;
     this.options = { stacking: true, multi: true, ...options };
     this.pendingDraw = 0;
     this.deck = createDeck();
     this.players.forEach(p => {
       p.hand = this.deck.splice(0, 7);
     });
-    if (ai) {
-      const aiPlayer = { id: `AI-${Date.now()}`, name: this.nextAIName(), hand: this.deck.splice(0, 7), ai: true };
+    for (let i = 0; i < aiCount; i++) {
+      const aiPlayer = {
+        id: `AI-${Date.now()}-${i}`,
+        name: this.nextAIName(),
+        hand: this.deck.splice(0, 7),
+        ai: true,
+      };
       this.players.push(aiPlayer);
     }
     let first = this.drawCard();


### PR DESCRIPTION
## Summary
- Allow starting games with multiple computer players
- Add admin controls to convert players to AI or remove them
- Enhance card play and draw animations with larger top card and penalty display
- Style title text with gradient

## Testing
- `cd server && npm test`
- `cd ../client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1df3546588327af80169a56d081a0