### PR TITLE
Delay AI turns and animate AI plays

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -121,6 +121,15 @@
   animation: playCard 0.8s ease forwards;
 }
 
+@keyframes aiPlay {
+  from { transform: scale(0.5); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+.card.ai-play {
+  animation: aiPlay 0.5s ease;
+}
+
 @keyframes drawCard {
   from { transform: translateY(-20px) scale(0.8); opacity: 0; }
   to { transform: translateY(0) scale(1); opacity: 1; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -141,6 +141,8 @@ function App() {
   const [stacking, setStacking] = useState(true);
   const [multi, setMulti] = useState(true);
   const [topChanging, setTopChanging] = useState(false);
+  const [aiPlaying, setAiPlaying] = useState(false);
+  const prevStateRef = useRef(null);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
@@ -250,6 +252,21 @@ function App() {
     const timeout = setTimeout(() => setTopChanging(false), 500);
     return () => clearTimeout(timeout);
   }, [topCard]);
+
+  useEffect(() => {
+    const prev = prevStateRef.current;
+    if (prev && state) {
+      const prevPlayer = prev.players.find(p => p.id === prev.current);
+      const topChanged =
+        prev.top && state.top && (prev.top.color !== state.top.color || prev.top.value !== state.top.value);
+      if (prevPlayer && prevPlayer.id.startsWith('AI-') && topChanged) {
+        setAiPlaying(true);
+        const t = setTimeout(() => setAiPlaying(false), 500);
+        return () => clearTimeout(t);
+      }
+    }
+    prevStateRef.current = state;
+  }, [state]);
 
   const joinLobby = (r) => {
     if (!name) return;
@@ -557,7 +574,7 @@ function App() {
         <div className="top-area">
           <h2>{t('topCard')}</h2>
           <div
-            className={`card ${state.top.color} top ${topChanging ? 'flipping' : ''}`}
+            className={`card ${state.top.color} top ${topChanging ? 'flipping' : ''} ${aiPlaying ? 'ai-play' : ''}`}
             aria-label={`${colorText(state.top.color)} ${valueText(state.top.value)}`}
           >
             {cardIcons[state.top.value] || state.top.value}

--- a/server/uno.js
+++ b/server/uno.js
@@ -33,7 +33,7 @@ class Game {
     this.started = false;
     this.discard = [];
     this.deck = [];
-    this.ai = null;
+    this.aiTimeout = null;
     this.winner = null;
     this.pendingDraw = 0;
     this.options = { stacking: true, multi: true };
@@ -250,34 +250,40 @@ class Game {
   checkAI(io, room) {
     const player = this.currentPlayer();
     if (!player || !player.ai) return;
-    const priority = { wild4: 5, draw2: 4, skip: 3, reverse: 2, swap: 2, wild: 1 };
-    const playable = player.hand.filter(c => c && this.canPlay(c));
-    if (playable.length) {
-      playable.sort((a, b) => (priority[b.value] || 0) - (priority[a.value] || 0));
-      let card = playable[0];
-      if (player.hand.length === 1 && (card.color === 'wild' || typeof card.value !== 'number')) {
-        const numeric = playable.find(c => typeof c.value === 'number');
-        if (numeric) card = numeric;
-        else {
-          this.draw(player.id);
-          io.to(room).emit('state', this.getState());
-          if (this.started) this.checkAI(io, room);
-          return;
+    if (this.aiTimeout) clearTimeout(this.aiTimeout);
+    this.aiTimeout = setTimeout(() => {
+      this.aiTimeout = null;
+      const player = this.currentPlayer();
+      if (!player || !player.ai) return;
+      const priority = { wild4: 5, draw2: 4, skip: 3, reverse: 2, swap: 2, wild: 1 };
+      const playable = player.hand.filter(c => c && this.canPlay(c));
+      if (playable.length) {
+        playable.sort((a, b) => (priority[b.value] || 0) - (priority[a.value] || 0));
+        let card = playable[0];
+        if (player.hand.length === 1 && (card.color === 'wild' || typeof card.value !== 'number')) {
+          const numeric = playable.find(c => typeof c.value === 'number');
+          if (numeric) card = numeric;
+          else {
+            this.draw(player.id);
+            io.to(room).emit('state', this.getState());
+            if (this.started) this.checkAI(io, room);
+            return;
+          }
         }
+        if (card.color === 'wild') {
+          const colorCounts = COLORS.map(color => ({
+            color,
+            count: player.hand.filter(c => c.color === color).length,
+          })).sort((a, b) => b.count - a.count);
+          card = { ...card, chosenColor: colorCounts[0].color };
+        }
+        this.play(player.id, card);
+      } else {
+        this.draw(player.id);
       }
-      if (card.color === 'wild') {
-        const colorCounts = COLORS.map(color => ({
-          color,
-          count: player.hand.filter(c => c.color === color).length,
-        })).sort((a, b) => b.count - a.count);
-        card = { ...card, chosenColor: colorCounts[0].color };
-      }
-      this.play(player.id, card);
-    } else {
-      this.draw(player.id);
-    }
-    io.to(room).emit('state', this.getState());
-    if (this.started) this.checkAI(io, room);
+      io.to(room).emit('state', this.getState());
+      if (this.started) this.checkAI(io, room);
+    }, 1000);
   }
 
   getState() {


### PR DESCRIPTION
## Summary
- Slow down AI actions using a 1s delay on the server
- Highlight AI card plays on the client with a new animation

## Testing
- `npm test`
- `npm run lint`
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a2138a1398832783a44785d1893154