### PR TITLE
Improve card play animations

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -33,6 +33,8 @@
   font-weight: bold;
   color: #fff;
   position: relative;
+  --dx: -40px;
+  --dy: -80px;
 }
 
 .card.red { background: #e74c3c; }
@@ -53,6 +55,8 @@
   height: 90px;
   font-size: 1.5rem;
   cursor: default;
+  --ai-dx: 0;
+  --ai-dy: -40px;
 }
 
 .top-area {
@@ -113,8 +117,8 @@
 }
 
 @keyframes playCard {
-  from { transform: translate(0,0) scale(1); opacity: 1; }
-  to { transform: translate(-40px,-80px) scale(0.8); opacity: 0.5; }
+  from { transform: translate(0, 0) scale(1); opacity: 1; }
+  to { transform: translate(var(--dx), var(--dy)) scale(0.8); opacity: 0.5; }
 }
 
 .card.playing {
@@ -122,12 +126,12 @@
 }
 
 @keyframes aiPlay {
-  from { transform: scale(0.5); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
+  from { transform: translate(var(--ai-dx), var(--ai-dy)) scale(0.5); opacity: 0; }
+  to { transform: translate(0, 0) scale(1); opacity: 1; }
 }
 
 .card.ai-play {
-  animation: aiPlay 0.5s ease;
+  animation: aiPlay 1s ease forwards;
 }
 
 @keyframes drawCard {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -143,6 +143,9 @@ function App() {
   const [topChanging, setTopChanging] = useState(false);
   const [aiPlaying, setAiPlaying] = useState(false);
   const prevStateRef = useRef(null);
+  const topCardRef = useRef(null);
+  const topTextRef = useRef(null);
+  const cardRefs = useRef([]);
 
   const myTurn = state?.current === id;
   const spectator = state ? !state.players.some(p => p.id === id) : false;
@@ -260,8 +263,16 @@ function App() {
       const topChanged =
         prev.top && state.top && (prev.top.color !== state.top.color || prev.top.value !== state.top.value);
       if (prevPlayer && prevPlayer.id.startsWith('AI-') && topChanged) {
+        if (topCardRef.current && topTextRef.current) {
+          const textRect = topTextRef.current.getBoundingClientRect();
+          const cardRect = topCardRef.current.getBoundingClientRect();
+          const dx = textRect.left + textRect.width / 2 - (cardRect.left + cardRect.width / 2);
+          const dy = textRect.top + textRect.height / 2 - (cardRect.top + cardRect.height / 2);
+          topCardRef.current.style.setProperty('--ai-dx', `${dx}px`);
+          topCardRef.current.style.setProperty('--ai-dy', `${dy}px`);
+        }
         setAiPlaying(true);
-        const t = setTimeout(() => setAiPlaying(false), 500);
+        const t = setTimeout(() => setAiPlaying(false), 1000);
         return () => clearTimeout(t);
       }
     }
@@ -347,6 +358,15 @@ function App() {
   };
 
   const performPlay = (cards, indices, target) => {
+    const cardEl = cardRefs.current[indices[0]];
+    if (cardEl && topCardRef.current) {
+      const cardRect = cardEl.getBoundingClientRect();
+      const topRect = topCardRef.current.getBoundingClientRect();
+      const dx = topRect.left + topRect.width / 2 - (cardRect.left + cardRect.width / 2);
+      const dy = topRect.top + topRect.height / 2 - (cardRect.top + cardRect.height / 2);
+      cardEl.style.setProperty('--dx', `${dx}px`);
+      cardEl.style.setProperty('--dy', `${dy}px`);
+    }
     setActionPending(true);
     setPlayingIndex(indices[0]);
     setSelected([]);
@@ -570,10 +590,11 @@ function App() {
       newCounts[k] = (newCounts[k] || 0) + 1;
     });
     content = (
-      <div className="game">
+        <div className="game">
         <div className="top-area">
-          <h2>{t('topCard')}</h2>
+          <h2 ref={topTextRef}>{t('topCard')}</h2>
           <div
+            ref={topCardRef}
             className={`card ${state.top.color} top ${topChanging ? 'flipping' : ''} ${aiPlaying ? 'ai-play' : ''}`}
             aria-label={`${colorText(state.top.color)} ${valueText(state.top.value)}`}
           >
@@ -619,6 +640,7 @@ function App() {
             return (
               <button
                 key={idx}
+                ref={el => (cardRefs.current[idx] = el)}
                 className={`card ${c.color} ${playingIndex === idx ? 'playing' : ''} ${playClass} ${isNew ? 'drawn' : ''} ${selected.includes(idx) ? 'selected' : ''}`}
                 onClick={spectator ? undefined : () => handleCardClick(c, idx)}
                 disabled={spectator || !myTurn || actionPending}


### PR DESCRIPTION
## Summary
- slow AI card animation from top card text to top card
- animate user card from selected card to top card

## Testing
- `npm test`
- `npm run lint`
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a21c93419c8327b15cf8e456116580