### PR TITLE
Improve AI animations and handling

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,7 +20,7 @@ const translations = {
     roomHeading: 'Room',
     start: 'Start',
     topCard: 'Top Card',
-    yourHand: 'Your hand',
+    yourHand: 'Turn:',
     yourTurn: '(Your turn)',
     draw: 'Draw',
     players: 'Players',
@@ -68,7 +68,7 @@ const translations = {
     roomHeading: 'Oda',
     start: 'Başlat',
     topCard: 'Üstteki kart',
-    yourHand: 'Eliniz',
+    yourHand: 'sira:',
     yourTurn: '(Sıra sizde)',
     draw: 'Kart Çek',
     players: 'Oyuncular',
@@ -250,11 +250,11 @@ function App() {
   }, [hand]);
 
   useEffect(() => {
-    if (!topCard) return;
+    if (!topCard || aiPlaying) return;
     setTopChanging(true);
     const timeout = setTimeout(() => setTopChanging(false), 500);
     return () => clearTimeout(timeout);
-  }, [topCard]);
+  }, [topCard, aiPlaying]);
 
   useEffect(() => {
     const prev = prevStateRef.current;
@@ -268,10 +268,19 @@ function App() {
           const cardRect = topCardRef.current.getBoundingClientRect();
           const dx = textRect.left + textRect.width / 2 - (cardRect.left + cardRect.width / 2);
           const dy = textRect.top + textRect.height / 2 - (cardRect.top + cardRect.height / 2);
-          topCardRef.current.style.setProperty('--ai-dx', `${dx}px`);
-          topCardRef.current.style.setProperty('--ai-dy', `${dy}px`);
+          const el = topCardRef.current;
+          el.style.setProperty('--ai-dx', `${dx}px`);
+          el.style.setProperty('--ai-dy', `${dy}px`);
+          el.style.transform = `translate(${dx}px, ${dy}px) scale(0.5)`;
+          el.style.opacity = '0';
+          requestAnimationFrame(() => {
+            el.style.removeProperty('transform');
+            el.style.removeProperty('opacity');
+            setAiPlaying(true);
+          });
+        } else {
+          setAiPlaying(true);
         }
-        setAiPlaying(true);
         const t = setTimeout(() => setAiPlaying(false), 1000);
         return () => clearTimeout(t);
       }

--- a/server/index.js
+++ b/server/index.js
@@ -86,7 +86,15 @@ io.on('connection', socket => {
 
   socket.on('kick', ({ room, target }) => {
     const game = games[room];
-    if (game && game.replaceWithAI(target)) {
+    if (!game) return;
+    if (target.startsWith('AI-')) {
+      game.removePlayer(target);
+      io.to(room).emit('state', game.getState());
+      game.checkAI(io, room);
+      if (!game.started) io.emit('lobbies', getLobbies());
+      return;
+    }
+    if (game.replaceWithAI(target)) {
       const targetSocket = io.sockets.sockets.get(target);
       if (targetSocket) targetSocket.leave(room);
       io.to(room).emit('state', game.getState());

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Smooth AI card play animation and prevent duplicate card display
- Allow kicking AI players from games
- Show `sira:` for the player's hand label
- Bump client and server versions

## Testing
- `npm test` (server)
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_68a22043c1b88327810a18a8f845697b