### PR TITLE
feat: enhance winner screen with animation and restart

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -455,19 +455,40 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.85);
-  color: #fff;
+  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+  color: #000;
   padding: 2rem 3rem;
   border-radius: 12px;
   font-size: 2rem;
-  animation: winnerPop 1s ease forwards;
+  animation: winnerPop 1s ease forwards, winnerPulse 2s ease-in-out 1s infinite;
   z-index: 1000;
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.7);
+  text-align: center;
 }
 
 @keyframes winnerPop {
   0% { transform: translate(-50%, -50%) scale(0.5); opacity: 0; }
   60% { transform: translate(-50%, -50%) scale(1.1); opacity: 1; }
   100% { transform: translate(-50%, -50%) scale(1); }
+}
+
+@keyframes winnerPulse {
+  0% { transform: translate(-50%, -50%) scale(1); box-shadow: 0 0 20px rgba(255, 255, 255, 0.7); }
+  50% { transform: translate(-50%, -50%) scale(1.05); box-shadow: 0 0 40px rgba(255, 255, 255, 1); }
+  100% { transform: translate(-50%, -50%) scale(1); box-shadow: 0 0 20px rgba(255, 255, 255, 0.7); }
+}
+
+.winner-banner button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.winner-banner button:hover {
+  background: #eee;
 }
 
 @media (max-width: 600px) {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -50,6 +50,7 @@ const translations = {
     turkish: 'Turkish',
     winner: 'Winner',
     wins: 'wins!',
+    restart: 'Restart',
     choosePlayer: 'Choose a player',
     activeLobbies: 'Active Rooms',
     chat: 'Chat',
@@ -98,6 +99,7 @@ const translations = {
     turkish: 'Türkçe',
     winner: 'Kazanan',
     wins: 'kazandı!',
+    restart: 'Yeniden Başla',
     choosePlayer: 'Bir oyuncu seçin',
     activeLobbies: 'Aktif Odalar',
     chat: 'Sohbet',
@@ -759,7 +761,8 @@ function App() {
       )}
       {state?.winner && (
         <div className="winner-banner">
-          {state.players.find(p => p.id === state.winner)?.name} {t('wins')}
+          <p>{state.players.find(p => p.id === state.winner)?.name} {t('wins')}</p>
+          <button onClick={start}>{t('restart')}</button>
         </div>
       )}
       {toast && <div className="toast">{toast}</div>}


### PR DESCRIPTION
## Summary
- Add pulsing gradient animation to winner banner for a more celebratory finish
- Provide a restart button on the winner banner using new i18n strings

## Testing
- `npm test` (client)
- `npm run lint` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a25921bd1c83278d9fdd04106a3744